### PR TITLE
feat: add toolbar control to clear conversation history

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,31 @@
 import {
+	Button,
+	Group,
+	Input,
+	Modal,
+	Popover,
+	Select,
+	Text,
+	Textarea,
+	UnstyledButton,
+} from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { get, set } from "idb-keyval";
+import { OpenAI } from "openai";
+import {
+	type MutableRefObject,
+	type ReactElement,
 	useEffect,
 	useRef,
 	useState,
-	type MutableRefObject,
-	type ReactElement,
 } from "react";
-import {
-	Button,
-	Input,
-	Select,
-	Textarea,
-	UnstyledButton,
-	Modal,
-	Popover,
-	Text,
-	Group,
-} from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import { OpenAI } from "openai";
-import { v4 as uuidv4 } from "uuid";
-import { useImmer } from "use-immer";
-import Markdown from "react-markdown";
 // import remarkGfm from "remark-gfm";
 import { useForm } from "react-hook-form";
+import Markdown from "react-markdown";
 import { Toaster, toast } from "sonner";
-import { get, set } from "idb-keyval";
 import { twJoin } from "tailwind-merge";
+import { useImmer } from "use-immer";
+import { v4 as uuidv4 } from "uuid";
 
 const baseURLKey = "iaslate_baseURL";
 const apiKeyKey = "iaslate_apiKey";
@@ -129,6 +129,19 @@ const App = () => {
 					/>
 				</div>
 				<div className="ml-auto flex gap-4">
+					<UnstyledButton
+						className="i-lucide-eraser w-5 h-5"
+						title="Clear conversation"
+						onClick={() => {
+							messagesList.forEach((message) => {
+								message._abortController?.abort?.();
+							});
+							setIsGenerating(false);
+							setEditingIndex(undefined);
+							setPrompt("");
+							setMessagesList([]);
+						}}
+					/>
 					<UnstyledButton
 						className="i-lucide-file-output w-5 h-5"
 						title="Export to JSON"


### PR DESCRIPTION
## Summary
- add a header eraser control alongside export and settings
- abort active responses and reset conversation state when the eraser is pressed

## Testing
- bunx biome check --write src/App.tsx

------
https://chatgpt.com/codex/tasks/task_e_68ff6707b68c83249abf9ae0aef935cb