### PR TITLE
refactor: restructure App component organization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,7 @@
 ## Project Structure & Module Organization
 
 - Source lives in `src/` (`index.tsx`, `App.tsx`, `index.css`). Build output goes to `dist/`.
-- Providers only in `index.tsx` (e.g., `MantineProvider`). All UI markup, styles, and logic stay in `App.tsx`.
-- Only two constructs in `App.tsx`: `App` and a `Component` helper. Imports, types, and constants may live at the top of the file; almost everything else belongs inside `App`.
+- Providers only in `index.tsx` (e.g., `MantineProvider`). `App.tsx` owns application state, while presentational pieces live in `src/components/`.
 - Key config: `rsbuild.config.mjs`, `tsconfig.json`, `tailwind.config.js`, `postcss.config.js`, `biome.json`.
 
 ## Build, Test, and Development Commands
@@ -19,39 +18,8 @@
 - Language: TypeScript + React 18; Tailwind for styling.
 - Indentation: one tab (Biome default). Keep code concise and self‑documenting.
 - Formatting: use Biome. Run `bunx biome check --write .` to format and organize imports.
-- Components: do not create new React components or files for UI. Use the `Component` helper as an inline pseudo‑component wherever a nested component would normally be used.
+- Components: prefer small presentational components in `src/components/`; keep core state and data flow inside `App.tsx`.
 - CSS: prefer Tailwind utilities; add global styles in `src/index.css` only when necessary.
-
-## UI Centralization & Component Helper
-
-- Everything UI‑related lives in `App`. The `Component` helper enables nesting JSX and hooks indefinitely without adding new components/files.
-- Example (inside `App.tsx`):
-  ```tsx
-  export function App() {
-    const [countA, setCountA] = useState(0);
-    return (
-      <>
-        <h3>Counters</h3>
-        <Component>
-          {() => {
-            const [countB, setCountB] = useState(0);
-            return (
-              <button
-                onClick={() => {
-                  setCountA((c) => c + 1);
-                  setCountB((c) => c + 2);
-                }}
-              >
-                CountA: {countA}, CountB: {countB}
-              </button>
-            );
-          }}
-        </Component>
-      </>
-    );
-  }
-  ```
-  Use `Component` wherever you would otherwise extract a child component.
 
 ## Testing Guidelines
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,6 @@ A tiny browser‑based chat UI packaged as a single static HTML file. It is inte
 - React 18, Mantine UI, Tailwind CSS
 - Rsbuild (Rspack)
 
-## Notes
-
-- The entire UI is deliberately written inside a single React component using a small helper to nest JSX and hooks indefinitely. It bends the usual Rules of Hooks as an experiment. A further discussion of the idea can be found here: [comp-in-one](https://github.com/CoolSpring8/comp-in-one).
-
 ## Related Projects
 
 - [lmg-anon/mikupad](https://github.com/lmg-anon/mikupad): LLM Frontend in a single html file

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,49 +1,21 @@
-import {
-	Button,
-	Group,
-	Input,
-	Modal,
-	Popover,
-	SegmentedControl,
-	Select,
-	Text,
-	Textarea,
-	UnstyledButton,
-} from "@mantine/core";
+import { Textarea, UnstyledButton } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { get, set } from "idb-keyval";
 import { OpenAI } from "openai";
-import {
-	type MutableRefObject,
-	type ReactElement,
-	useEffect,
-	useRef,
-	useState,
-} from "react";
-// import remarkGfm from "remark-gfm";
-import { useForm } from "react-hook-form";
-import Markdown from "react-markdown";
+import { type MutableRefObject, useEffect, useRef, useState } from "react";
 import { Toaster, toast } from "sonner";
 import { twJoin } from "tailwind-merge";
 import { useImmer } from "use-immer";
 import { v4 as uuidv4 } from "uuid";
 import DiagramView from "./components/DiagramView";
+import Header from "./components/Header";
+import MessageItem from "./components/MessageItem";
+import SettingsModal from "./components/SettingsModal";
+import type { Message } from "./types";
 
 const baseURLKey = "iaslate_baseURL";
 const apiKeyKey = "iaslate_apiKey";
 const modelsKey = "iaslate_models";
-
-interface Message {
-	role: string;
-	content: string;
-	_metadata: {
-		uuid: string;
-	};
-	_abortController?: AbortController;
-}
-
-const Component = ({ children }: { children: () => ReactElement }) =>
-	children();
 
 const App = () => {
 	const [messagesList, setMessagesList] = useImmer<Message[]>([
@@ -57,19 +29,15 @@ const App = () => {
 	]);
 
 	const [baseURL, setBaseURL] = useState("");
-
 	const [apiKey, setAPIKey] = useState("");
-
 	const [models, setModels] = useImmer<OpenAI.Model[]>([]);
-
 	const [activeModel, setActiveModel] = useImmer<string | null>(null);
 
 	const client = (() => {
 		const ref = useRef<OpenAI | null>(null);
 		if (!ref.current) {
 			ref.current = new OpenAI({
-				baseURL: baseURL,
-				// Avoid "Missing OpenAI API key" error
+				baseURL,
 				apiKey: apiKey || "_PLACEHOLDER_",
 				dangerouslyAllowBrowser: true,
 			});
@@ -83,11 +51,11 @@ const App = () => {
 			if (storedBaseURL) {
 				setBaseURL(storedBaseURL);
 			}
-			const storedAPIKey = await get(apiKeyKey);
+			const storedAPIKey = await get<string>(apiKeyKey);
 			if (storedAPIKey) {
 				setAPIKey(storedAPIKey);
 			}
-			const storedModels = await get(modelsKey);
+			const storedModels = await get<OpenAI.Model[]>(modelsKey);
 			if (storedModels) {
 				setModels(storedModels);
 			}
@@ -106,16 +74,14 @@ const App = () => {
 	}, []);
 
 	const [isGenerating, setIsGenerating] = useState(false);
-
 	const [prompt, setPrompt] = useImmer("");
-
 	const [isSettingsOpen, { open: onSettingsOpen, close: onSettingsClose }] =
 		useDisclosure();
-
 	const [editingIndex, setEditingIndex] = useState<number | undefined>(
 		undefined,
 	);
 	const [view, setView] = useState<"chat" | "diagram">("chat");
+	const isComposing = useRef(false);
 
 	useEffect(() => {
 		const handleBeforeUnload = (event: BeforeUnloadEvent) => {
@@ -138,365 +104,301 @@ const App = () => {
 		};
 	}, [isGenerating, prompt, editingIndex, messagesList.length]);
 
+	const handleClearConversation = () => {
+		messagesList.forEach((message) => {
+			message._abortController?.abort?.();
+		});
+		setIsGenerating(false);
+		setEditingIndex(undefined);
+		setPrompt("");
+		setMessagesList([]);
+	};
+
+	const handleExport = () => {
+		const blob = new Blob([JSON.stringify(messagesList, null, 2)], {
+			type: "application/json",
+		});
+		const url = URL.createObjectURL(blob);
+		const anchor = document.createElement("a");
+		anchor.href = url;
+		anchor.download = `messages_${new Date().toISOString()}.json`;
+		anchor.click();
+		URL.revokeObjectURL(url);
+		toast.success("Exported to JSON");
+	};
+
+	const handleEditMessage = (index: number) => {
+		const targetMessage = messagesList[index];
+		if (!targetMessage) {
+			return;
+		}
+		setEditingIndex(index);
+		setPrompt(targetMessage.content);
+	};
+
+	const handleDeleteMessage = (index: number) => {
+		const targetMessage = messagesList[index];
+		if (!targetMessage) {
+			return;
+		}
+		targetMessage._abortController?.abort?.();
+		if (typeof editingIndex !== "undefined") {
+			if (editingIndex === index) {
+				setEditingIndex(undefined);
+				setPrompt("");
+			} else if (editingIndex > index) {
+				setEditingIndex(editingIndex - 1);
+			}
+		}
+		setIsGenerating(false);
+		setMessagesList((draft) => {
+			draft.splice(index, 1);
+		});
+	};
+
+	const handleDetachMessages = (index: number) => {
+		const targetMessage = messagesList[index];
+		targetMessage?._abortController?.abort?.();
+		if (isGenerating) {
+			setIsGenerating(false);
+		}
+		if (typeof editingIndex !== "undefined" && editingIndex >= index) {
+			setEditingIndex(undefined);
+			setPrompt("");
+		}
+		setMessagesList((messages) => messages.slice(0, index));
+	};
+
+	const handleSend = async () => {
+		setPrompt("");
+		const assistantMessageUUID = uuidv4();
+		const assistantAbortController = new AbortController();
+		const messagesNew = prompt
+			? [
+					...messagesList,
+					{
+						role: "user",
+						content: prompt,
+						_metadata: {
+							uuid: uuidv4(),
+						},
+					},
+					{
+						role: "assistant",
+						content: "",
+						_metadata: {
+							uuid: assistantMessageUUID,
+						},
+						_abortController: assistantAbortController,
+					},
+				]
+			: [
+					...messagesList,
+					{
+						role: "assistant",
+						content: "",
+						_metadata: {
+							uuid: assistantMessageUUID,
+						},
+						_abortController: assistantAbortController,
+					},
+				];
+		setMessagesList(messagesNew);
+		const stream = await client.current.chat.completions.create(
+			{
+				model: activeModel,
+				messages: messagesNew
+					.map((message) => ({
+						role: message.role,
+						content: message.content,
+					}))
+					.slice(0, -1),
+				// max_tokens: 2048,
+				stream: true,
+				temperature: 0.3,
+				// cache_prompt: true,
+			},
+			{
+				signal: assistantAbortController.signal,
+			},
+		);
+		setIsGenerating(true);
+		for await (const chunk of stream) {
+			setMessagesList((draft) => {
+				const targetMessage = draft.find(
+					(message) => message._metadata.uuid === assistantMessageUUID,
+				);
+				if (
+					chunk.choices[0].delta.content &&
+					!assistantAbortController.signal.aborted &&
+					typeof targetMessage !== "undefined"
+				) {
+					targetMessage.content =
+						targetMessage.content + chunk.choices[0].delta.content;
+				}
+			});
+		}
+		setIsGenerating(false);
+	};
+
+	const handleFinishEdit = () => {
+		if (typeof editingIndex === "undefined") {
+			return;
+		}
+		setMessagesList((draft) => {
+			draft[editingIndex].content = prompt;
+		});
+		setEditingIndex(undefined);
+		setPrompt("");
+	};
+
+	const handleSubmit = () => {
+		if (isGenerating) {
+			messagesList[messagesList.length - 1]?._abortController?.abort?.();
+			return;
+		}
+		if (typeof editingIndex !== "undefined") {
+			handleFinishEdit();
+			return;
+		}
+		void handleSend();
+	};
+
+	const handleSettingsSave = async ({
+		baseURL: nextBaseURL,
+		apiKey: nextAPIKey,
+	}: {
+		baseURL: string;
+		apiKey: string;
+	}) => {
+		setBaseURL(nextBaseURL);
+		await set(baseURLKey, nextBaseURL);
+		setAPIKey(nextAPIKey);
+		await set(apiKeyKey, nextAPIKey);
+		client.current = new OpenAI({
+			baseURL: nextBaseURL,
+			apiKey: nextAPIKey,
+			dangerouslyAllowBrowser: true,
+		});
+		onSettingsClose();
+	};
+
+	const handleSyncModels = async () => {
+		const response = await client.current.models.list();
+		setModels(response.data);
+		await set(modelsKey, response.data);
+		if (!activeModel) {
+			setActiveModel(response.data[0].id);
+		}
+	};
+
 	return (
 		<div className="flex flex-col h-screen">
-			<div className="flex items-center px-4 py-2">
-				<div className="flex items-center gap-2">
-					<h1 className="text-xl font-bold font-mono">iaslate</h1>
-					<Select
-						className="w-64"
-						data={models.map((m) => ({ value: m.id, label: m.name || m.id }))}
-						value={activeModel}
-						onChange={setActiveModel}
-						placeholder="Select a model"
-						aria-label="Select a model"
-					/>
-				</div>
-				<div className="ml-4">
-					<SegmentedControl
-						size="sm"
-						value={view}
-						onChange={(value) => setView(value as "chat" | "diagram")}
-						data={[
-							{ label: "Chat", value: "chat" },
-							{ label: "Diagram", value: "diagram" },
-						]}
-						aria-label="View switch"
-					/>
-				</div>
-				<div className="ml-auto flex gap-4">
-					<UnstyledButton
-						className="i-lucide-eraser w-5 h-5"
-						title="Clear conversation"
-						onClick={() => {
-							messagesList.forEach((message) => {
-								message._abortController?.abort?.();
-							});
-							setIsGenerating(false);
-							setEditingIndex(undefined);
-							setPrompt("");
-							setMessagesList([]);
-						}}
-					/>
-					<UnstyledButton
-						className="i-lucide-file-output w-5 h-5"
-						title="Export to JSON"
-						onClick={() => {
-							const blob = new Blob([JSON.stringify(messagesList, null, 2)], {
-								type: "application/json",
-							});
-							const url = URL.createObjectURL(blob);
-							const a = document.createElement("a");
-							a.href = url;
-							a.download = `messages_${new Date().toISOString()}.json`;
-							a.click();
-							URL.revokeObjectURL(url);
-							toast.success("Exported to JSON");
-						}}
-					/>
-					<UnstyledButton
-						className="i-lucide-settings w-5 h-5"
-						title="Settings"
-						onClick={onSettingsOpen}
-					/>
-				</div>
-			</div>
+			<Header
+				models={models}
+				activeModel={activeModel}
+				onModelChange={setActiveModel}
+				view={view}
+				onViewChange={setView}
+				onClear={handleClearConversation}
+				onExport={handleExport}
+				onOpenSettings={onSettingsOpen}
+			/>
 			{view === "chat" ? (
 				<>
 					<div
 						className="flex-1 overflow-y-auto px-4 py-2"
-						onDrop={async (e) => {
-							e.preventDefault();
-							if (e.dataTransfer.items) {
-								for (const item of e.dataTransfer.items) {
+						onDrop={async (event) => {
+							event.preventDefault();
+							if (event.dataTransfer.items) {
+								for (const item of event.dataTransfer.items) {
 									if (item.kind === "file") {
 										const file = item.getAsFile();
 										if (file) {
 											const content = await file.text();
-											setPrompt((draft) => {
-												draft += content;
-											});
+											setPrompt((draft) => draft + content);
 										}
 									}
 								}
 							}
 						}}
-						onDragOver={(e) => {
-							e.preventDefault();
+						onDragOver={(event) => {
+							event.preventDefault();
 						}}
 					>
 						{messagesList.map((message, index) => (
-							<Component key={message._metadata.uuid}>
-								{() => {
-									const [isHovered, setIsHovered] = useState(false);
-									const [hasBeenClicked, setHasBeenClicked] = useState(false);
-									return (
-										<div
-											className={twJoin(
-												"mb-2 hover:bg-slate-50",
-												editingIndex === index && "bg-sky-100 opacity-50",
-											)}
-											onMouseOver={() => setIsHovered(true)}
-											onMouseLeave={() => setIsHovered(false)}
-										>
-											<div className="flex items-center gap-2">
-												<p
-													className="my-0 font-bold"
-													onClick={() => {
-														setHasBeenClicked((v) => !v);
-													}}
-												>
-													{message.role}
-												</p>
-												{(hasBeenClicked || isHovered) && (
-													<>
-														<UnstyledButton
-															className="i-lucide-copy text-slate-400 hover:text-slate-600 transition"
-															onClick={() => {
-																try {
-																	navigator.clipboard.writeText(
-																		message.content,
-																	);
-																	toast("Copied to clipboard", {
-																		position: "top-center",
-																	});
-																} catch (e) {
-																	toast("Failed to copy to clipboard");
-																}
-															}}
-														/>
-														<UnstyledButton
-															className="i-lucide-edit text-slate-400 hover:text-slate-600 transition"
-															onClick={() => {
-																setEditingIndex(index);
-																setPrompt(message.content);
-															}}
-														/>
-														<Popover width={200} position="bottom" withArrow>
-															<Popover.Target>
-																<UnstyledButton className="i-lucide-trash text-slate-400 hover:text-slate-600 transition" />
-															</Popover.Target>
-															<Popover.Dropdown>
-																<div className="flex flex-col">
-																	<Text>Delete?</Text>
-																	<Button
-																		className="min-w-0 h-auto flex-1 !p-1 text-xs self-end"
-																		onClick={() => {
-																			message._abortController?.abort?.();
-																			if (typeof editingIndex !== "undefined") {
-																				setEditingIndex(
-																					editingIndex === index
-																						? undefined
-																						: editingIndex > index
-																							? editingIndex - 1
-																							: editingIndex,
-																				);
-																			}
-																			setIsGenerating(false);
-																			setMessagesList((draft) => {
-																				draft.splice(index, 1);
-																			});
-																		}}
-																	>
-																		Yes
-																	</Button>
-																</div>
-															</Popover.Dropdown>
-														</Popover>
-														<UnstyledButton
-															className="i-lucide-unlink text-slate-400 hover:text-slate-600 transition"
-															onClick={() => {
-																messagesList[index]._abortController?.abort?.();
-																if (isGenerating) {
-																	setIsGenerating(false);
-																}
-																if (
-																	typeof editingIndex !== "undefined" &&
-																	editingIndex >= index
-																) {
-																	setEditingIndex(undefined);
-																	setPrompt("");
-																}
-																setMessagesList((m) => m.slice(0, index));
-															}}
-														/>
-													</>
-												)}
-											</div>
-											<div className="twp prose prose-p:whitespace-pre-wrap">
-												<Markdown remarkPlugins={[]}>
-													{`${message.content}${
-														index === messagesList.length - 1 && isGenerating
-															? "▪️"
-															: ""
-													}`}
-												</Markdown>
-											</div>
-										</div>
-									);
-								}}
-							</Component>
+							<MessageItem
+								key={message._metadata.uuid}
+								message={message}
+								isEditing={editingIndex === index}
+								isLast={index === messagesList.length - 1}
+								isGenerating={isGenerating}
+								onEdit={() => handleEditMessage(index)}
+								onDelete={() => handleDeleteMessage(index)}
+								onDetach={() => handleDetachMessages(index)}
+							/>
 						))}
 					</div>
-					<Component>
-						{() => {
-							const isComposing = useRef(false);
-							const handleSend = async () => {
-								setPrompt("");
-								const assistantMessageUUID = uuidv4();
-								const assistantAbortController = new AbortController();
-								const messagesNew = prompt
-									? [
-											...messagesList,
-											{
-												role: "user",
-												content: prompt,
-												_metadata: {
-													uuid: uuidv4(),
-												},
-											},
-											{
-												role: "assistant",
-												content: "",
-												_metadata: {
-													uuid: assistantMessageUUID,
-												},
-												_abortController: assistantAbortController,
-											},
-										]
-									: [
-											...messagesList,
-											{
-												role: "assistant",
-												content: "",
-												_metadata: {
-													uuid: assistantMessageUUID,
-												},
-												_abortController: assistantAbortController,
-											},
-										];
-								setMessagesList(messagesNew);
-								const stream = await client.current.chat.completions.create(
-									{
-										model: activeModel,
-										messages: messagesNew
-											.map((m) => ({
-												role: m.role,
-												content: m.content,
-											}))
-											.slice(0, -1),
-										// max_tokens: 2048,
-										stream: true,
-										temperature: 0.3,
-										// cache_prompt: true,
-									},
-									{
-										signal: assistantAbortController.signal,
-									},
-								);
-								setIsGenerating(true);
-								for await (const chunk of stream) {
-									setMessagesList((draft) => {
-										const targetMessage = draft.find(
-											(m) => m._metadata.uuid === assistantMessageUUID,
-										);
-										if (
-											chunk.choices[0].delta.content &&
-											!assistantAbortController.signal.aborted &&
-											typeof targetMessage !== "undefined"
-										) {
-											targetMessage.content =
-												targetMessage.content + chunk.choices[0].delta.content;
-										}
-									});
-								}
-								setIsGenerating(false);
-							};
-							const handleFinishEdit = () => {
-								setMessagesList((draft) => {
-									draft[editingIndex as number].content = prompt;
-								});
-								setEditingIndex(undefined);
-								setPrompt("");
-							};
-							const handleSubmit = () => {
-								if (isGenerating) {
-									messagesList[
-										messagesList.length - 1
-									]._abortController?.abort?.();
-									return;
-								}
-								if (typeof editingIndex !== "undefined") {
-									handleFinishEdit();
-								} else {
-									handleSend();
-								}
-							};
-							return (
-								<div className="relative px-4 py-2">
-									<div className="flex items-center">
-										<Textarea
-											className="w-full"
-											minRows={1}
-											maxRows={5}
-											placeholder="Type your message..."
-											value={prompt}
-											onChange={async (e) => {
-												const v = e.target.value;
-												setPrompt(v);
-											}}
-											onCompositionStart={() => {
-												isComposing.current = true;
-											}}
-											onCompositionEnd={() => {
-												isComposing.current = false;
-											}}
-											onKeyDown={async (e) => {
-												if (
-													e.key === "Enter" &&
-													!e.shiftKey &&
-													!e.nativeEvent.isComposing &&
-													!isComposing.current
-												) {
-													e.preventDefault();
-													handleSubmit();
-												}
-											}}
-										/>
-										<UnstyledButton
-											className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
-											onClick={handleSubmit}
-										>
-											<div
-												className={twJoin(
-													"w-4 h-4",
-													typeof editingIndex !== "undefined"
-														? "i-lucide-check"
-														: "i-lucide-send-horizontal",
-													isGenerating ? "animate-spin" : "",
-												)}
-											/>
-										</UnstyledButton>
-									</div>
-									{typeof editingIndex !== "undefined" && (
-										<div className="absolute left-4 -top-8 h-8 w-[calc(100%-2rem)] rounded bg-orange-300 p-2 flex items-center text-slate-700 text-sm">
-											<div className="i-lucide-edit flex-none" />
-											<p className="ml-1 line-clamp-1">
-												Editing: {messagesList[editingIndex].content}
-											</p>
-											<UnstyledButton
-												className="i-lucide-x ml-auto flex-none"
-												onClick={() => {
-													setEditingIndex(undefined);
-													setPrompt("");
-												}}
-											/>
-										</div>
+					<div className="relative px-4 py-2">
+						<div className="flex items-center">
+							<Textarea
+								className="w-full"
+								minRows={1}
+								maxRows={5}
+								placeholder="Type your message..."
+								value={prompt}
+								onChange={(event) => {
+									setPrompt(event.target.value);
+								}}
+								onCompositionStart={() => {
+									isComposing.current = true;
+								}}
+								onCompositionEnd={() => {
+									isComposing.current = false;
+								}}
+								onKeyDown={(event) => {
+									if (
+										event.key === "Enter" &&
+										!event.shiftKey &&
+										!event.nativeEvent.isComposing &&
+										!isComposing.current
+									) {
+										event.preventDefault();
+										handleSubmit();
+									}
+								}}
+							/>
+							<UnstyledButton
+								className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
+								onClick={handleSubmit}
+							>
+								<div
+									className={twJoin(
+										"w-4 h-4",
+										typeof editingIndex !== "undefined"
+											? "i-lucide-check"
+											: "i-lucide-send-horizontal",
+										isGenerating ? "animate-spin" : "",
 									)}
-								</div>
-							);
-						}}
-					</Component>
+								/>
+							</UnstyledButton>
+						</div>
+						{typeof editingIndex !== "undefined" && (
+							<div className="absolute left-4 -top-8 h-8 w-[calc(100%-2rem)] rounded bg-orange-300 p-2 flex items-center text-slate-700 text-sm">
+								<div className="i-lucide-edit flex-none" />
+								<p className="ml-1 line-clamp-1">
+									Editing: {messagesList[editingIndex].content}
+								</p>
+								<UnstyledButton
+									className="i-lucide-x ml-auto flex-none"
+									onClick={() => {
+										setEditingIndex(undefined);
+										setPrompt("");
+									}}
+								/>
+							</div>
+						)}
+					</div>
 				</>
 			) : (
 				<div className="flex-1 overflow-hidden px-2 py-2">
@@ -514,91 +416,14 @@ const App = () => {
 					/>
 				</div>
 			)}
-			<Component>
-				{() => {
-					const { register, handleSubmit } = useForm();
-
-					return (
-						<Modal
-							opened={isSettingsOpen}
-							onClose={onSettingsClose}
-							title="Settings"
-						>
-							<form
-								onSubmit={handleSubmit(async (data) => {
-									setBaseURL(data["baseURL"]);
-									await set(baseURLKey, data["baseURL"]);
-									setAPIKey(data["apiKey"]);
-									await set(apiKeyKey, data["apiKey"]);
-									client.current = new OpenAI({
-										baseURL: data["baseURL"],
-										apiKey: data["apiKey"],
-										dangerouslyAllowBrowser: true,
-									});
-									onSettingsClose();
-								})}
-							>
-								<Input
-									{...register("baseURL", { required: true })}
-									defaultValue={baseURL}
-									// In Mantine, use "rightSection" instead of "endContent"
-									rightSection={
-										<div className="i-lucide-server text-lg text-default-400 pointer-events-none flex-shrink-0" />
-									}
-									label="OpenAI-Compatible API Base"
-									placeholder="https://.../v1"
-									type="url"
-								/>
-								<Component>
-									{() => {
-										const [isVisible, setIsVisible] = useState(false);
-										return (
-											<Input
-												{...register("apiKey", { required: true })}
-												defaultValue={apiKey}
-												rightSection={
-													<UnstyledButton
-														className="focus:outline-none"
-														type="button"
-														onClick={() => setIsVisible((v) => !v)}
-													>
-														{isVisible ? (
-															<div className="i-lucide-eye text-lg text-default-400 pointer-events-none" />
-														) : (
-															<div className="i-lucide-eye-off text-lg text-default-400 pointer-events-none" />
-														)}
-													</UnstyledButton>
-												}
-												label="API Key"
-												placeholder="sk-..."
-												type={isVisible ? "text" : "password"}
-											/>
-										);
-									}}
-								</Component>
-								<div className="flex items-center justify-between mt-4">
-									<p>Models</p>
-									<Button
-										onClick={async () => {
-											const response = await client.current.models.list();
-											setModels(response.data);
-											await set(modelsKey, response.data);
-											if (!activeModel) {
-												setActiveModel(response.data[0].id);
-											}
-										}}
-									>
-										Sync from API
-									</Button>
-								</div>
-								<Group justify="flex-end" mt="md">
-									<Button type="submit">Save</Button>
-								</Group>
-							</form>
-						</Modal>
-					);
-				}}
-			</Component>
+			<SettingsModal
+				open={isSettingsOpen}
+				baseURL={baseURL}
+				apiKey={apiKey}
+				onClose={onSettingsClose}
+				onSave={handleSettingsSave}
+				onSyncModels={handleSyncModels}
+			/>
 			<Toaster />
 		</div>
 	);

--- a/src/components/DiagramView.tsx
+++ b/src/components/DiagramView.tsx
@@ -8,15 +8,10 @@ import {
 } from "@xyflow/react";
 import { type CSSProperties, useMemo } from "react";
 import "@xyflow/react/dist/style.css";
-
-export interface DiagramMessage {
-	role: string;
-	content: string;
-	_metadata: { uuid: string };
-}
+import type { Message } from "../types";
 
 interface DiagramViewProps {
-	messages: DiagramMessage[];
+	messages: Message[];
 	onNodeDoubleClick?: (index: number) => void;
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,71 @@
+import { SegmentedControl, Select, UnstyledButton } from "@mantine/core";
+
+interface HeaderProps {
+	models: Array<{ id: string; name?: string | null }>;
+	activeModel: string | null;
+	onModelChange: (value: string | null) => void;
+	view: "chat" | "diagram";
+	onViewChange: (value: "chat" | "diagram") => void;
+	onClear: () => void;
+	onExport: () => void;
+	onOpenSettings: () => void;
+}
+
+const Header = ({
+	models,
+	activeModel,
+	onModelChange,
+	view,
+	onViewChange,
+	onClear,
+	onExport,
+	onOpenSettings,
+}: HeaderProps) => (
+	<div className="flex items-center px-4 py-2">
+		<div className="flex items-center gap-2">
+			<h1 className="text-xl font-bold font-mono">iaslate</h1>
+			<Select
+				className="w-64"
+				data={models.map((model) => ({
+					value: model.id,
+					label: model.name || model.id,
+				}))}
+				value={activeModel}
+				onChange={onModelChange}
+				placeholder="Select a model"
+				aria-label="Select a model"
+			/>
+		</div>
+		<div className="ml-4">
+			<SegmentedControl
+				size="sm"
+				value={view}
+				onChange={(value) => onViewChange(value as "chat" | "diagram")}
+				data={[
+					{ label: "Chat", value: "chat" },
+					{ label: "Diagram", value: "diagram" },
+				]}
+				aria-label="View switch"
+			/>
+		</div>
+		<div className="ml-auto flex gap-4">
+			<UnstyledButton
+				className="i-lucide-eraser w-5 h-5"
+				title="Clear conversation"
+				onClick={onClear}
+			/>
+			<UnstyledButton
+				className="i-lucide-file-output w-5 h-5"
+				title="Export to JSON"
+				onClick={onExport}
+			/>
+			<UnstyledButton
+				className="i-lucide-settings w-5 h-5"
+				title="Settings"
+				onClick={onOpenSettings}
+			/>
+		</div>
+	</div>
+);
+
+export default Header;

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -1,0 +1,101 @@
+import { Button, Popover, Text, UnstyledButton } from "@mantine/core";
+import { useState } from "react";
+import Markdown from "react-markdown";
+import { toast } from "sonner";
+import { twJoin } from "tailwind-merge";
+import type { Message } from "../types";
+
+interface MessageItemProps {
+	message: Message;
+	isEditing: boolean;
+	isLast: boolean;
+	isGenerating: boolean;
+	onEdit: () => void;
+	onDelete: () => void;
+	onDetach: () => void;
+}
+
+const MessageItem = ({
+	message,
+	isEditing,
+	isLast,
+	isGenerating,
+	onEdit,
+	onDelete,
+	onDetach,
+}: MessageItemProps) => {
+	const [isHovered, setIsHovered] = useState(false);
+	const [hasBeenClicked, setHasBeenClicked] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			await navigator.clipboard.writeText(message.content);
+			toast("Copied to clipboard", {
+				position: "top-center",
+			});
+		} catch (error) {
+			toast("Failed to copy to clipboard");
+		}
+	};
+
+	return (
+		<div
+			className={twJoin(
+				"mb-2 hover:bg-slate-50",
+				isEditing && "bg-sky-100 opacity-50",
+			)}
+			onMouseOver={() => setIsHovered(true)}
+			onMouseLeave={() => setIsHovered(false)}
+		>
+			<div className="flex items-center gap-2">
+				<p
+					className="my-0 font-bold"
+					onClick={() => {
+						setHasBeenClicked((value) => !value);
+					}}
+				>
+					{message.role}
+				</p>
+				{(hasBeenClicked || isHovered) && (
+					<>
+						<UnstyledButton
+							className="i-lucide-copy text-slate-400 hover:text-slate-600 transition"
+							onClick={handleCopy}
+						/>
+						<UnstyledButton
+							className="i-lucide-edit text-slate-400 hover:text-slate-600 transition"
+							onClick={onEdit}
+						/>
+						<Popover width={200} position="bottom" withArrow>
+							<Popover.Target>
+								<UnstyledButton className="i-lucide-trash text-slate-400 hover:text-slate-600 transition" />
+							</Popover.Target>
+							<Popover.Dropdown>
+								<div className="flex flex-col">
+									<Text>Delete?</Text>
+									<Button
+										className="min-w-0 h-auto flex-1 !p-1 text-xs self-end"
+										onClick={onDelete}
+									>
+										Yes
+									</Button>
+								</div>
+							</Popover.Dropdown>
+						</Popover>
+						<UnstyledButton
+							className="i-lucide-unlink text-slate-400 hover:text-slate-600 transition"
+							onClick={onDetach}
+						/>
+					</>
+				)}
+			</div>
+			<div className="twp prose prose-p:whitespace-pre-wrap">
+				<Markdown remarkPlugins={[]}>
+					{`${message.content}${isLast && isGenerating ? "▪️" : ""}`}
+				</Markdown>
+			</div>
+		</div>
+	);
+};
+
+export default MessageItem;

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,0 +1,95 @@
+import { Button, Group, Input, Modal, UnstyledButton } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+
+interface SettingsFormValues {
+	baseURL: string;
+	apiKey: string;
+}
+
+interface SettingsModalProps {
+	open: boolean;
+	baseURL: string;
+	apiKey: string;
+	onClose: () => void;
+	onSave: (values: SettingsFormValues) => Promise<void> | void;
+	onSyncModels: () => Promise<void> | void;
+}
+
+const SettingsModal = ({
+	open,
+	baseURL,
+	apiKey,
+	onClose,
+	onSave,
+	onSyncModels,
+}: SettingsModalProps) => {
+	const { register, handleSubmit, reset } = useForm<SettingsFormValues>({
+		defaultValues: {
+			baseURL,
+			apiKey,
+		},
+	});
+	const [isVisible, setIsVisible] = useState(false);
+
+	useEffect(() => {
+		if (open) {
+			reset({ baseURL, apiKey });
+		}
+	}, [apiKey, baseURL, open, reset]);
+
+	return (
+		<Modal opened={open} onClose={onClose} title="Settings">
+			<form
+				onSubmit={handleSubmit(async (values) => {
+					await onSave(values);
+				})}
+			>
+				<Input
+					{...register("baseURL", { required: true })}
+					// In Mantine, use "rightSection" instead of "endContent"
+					rightSection={
+						<div className="i-lucide-server text-lg text-default-400 pointer-events-none flex-shrink-0" />
+					}
+					label="OpenAI-Compatible API Base"
+					placeholder="https://.../v1"
+					type="url"
+				/>
+				<Input
+					{...register("apiKey", { required: true })}
+					rightSection={
+						<UnstyledButton
+							className="focus:outline-none"
+							type="button"
+							onClick={() => setIsVisible((value) => !value)}
+						>
+							{isVisible ? (
+								<div className="i-lucide-eye text-lg text-default-400 pointer-events-none" />
+							) : (
+								<div className="i-lucide-eye-off text-lg text-default-400 pointer-events-none" />
+							)}
+						</UnstyledButton>
+					}
+					label="API Key"
+					placeholder="sk-..."
+					type={isVisible ? "text" : "password"}
+				/>
+				<div className="flex items-center justify-between mt-4">
+					<p>Models</p>
+					<Button
+						onClick={() => {
+							void onSyncModels();
+						}}
+					>
+						Sync from API
+					</Button>
+				</div>
+				<Group justify="flex-end" mt="md">
+					<Button type="submit">Save</Button>
+				</Group>
+			</form>
+		</Modal>
+	);
+};
+
+export default SettingsModal;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+export interface Message {
+	role: string;
+	content: string;
+	_metadata: {
+		uuid: string;
+	};
+	_abortController?: AbortController;
+}


### PR DESCRIPTION
- Moved presentational components to `src/components/` for better modularity.
- Updated `AGENTS.md` to reflect changes in component structure and guidelines.
- Removed the `Component` helper in favor of direct usage of presentational components.
- Simplified the `App` component by integrating `Header`, `MessageItem`, and `SettingsModal` components.
- Improved state management and event handling for message operations.