### PR TITLE
feat: add text completion mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import SettingsModal from "./components/SettingsModal";
 import TextCompletionView from "./components/TextCompletionView";
 import type { ConversationSnapshot } from "./tree/types";
 import { useConversationTree } from "./tree/useConversationTree";
+import type { AppView } from "./types";
 
 const baseURLKey = "iaslate_baseURL";
 const apiKeyKey = "iaslate_apiKey";
@@ -121,7 +122,7 @@ const App = () => {
 	const [editingNodeId, setEditingNodeId] = useState<string | undefined>(
 		undefined,
 	);
-	const [view, setView] = useState<"chat" | "diagram" | "text">("chat");
+	const [view, setView] = useState<AppView>("chat");
 	const isComposing = useRef(false);
 	const {
 		nodes: treeNodes,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -367,22 +367,21 @@ const App = () => {
 		textAbortControllerRef.current = abortController;
 		setIsTextGenerating(true);
 		try {
-			const stream = await client.current.responses.create(
+			const stream = await client.current.completions.create(
 				{
 					model: activeModel,
-					input: textContent.length > 0 ? textContent : " ",
+					prompt: textContent.length > 0 ? textContent : " ",
 					stream: true,
 					temperature: 0.3,
 				},
 				{ signal: abortController.signal },
 			);
 			for await (const event of stream) {
-				if (event.type === "response.output_text.delta") {
-					const delta = event.delta;
-					if (delta) {
-						setTextContent((draft) => draft + delta);
-					}
+				const delta = event.choices.at(0)?.text;
+				if (!delta) {
+					continue;
 				}
+				setTextContent((draft) => draft + delta);
 			}
 		} catch (error) {
 			if (abortController.signal.aborted) {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,16 @@ interface HeaderProps {
 	onOpenSettings: () => void;
 }
 
+const viewOptions: Array<{
+	label: string;
+	value: "chat" | "diagram" | "text";
+	icon: string;
+}> = [
+	{ label: "Chat", value: "chat", icon: "i-lucide-message-square" },
+	{ label: "Diagram", value: "diagram", icon: "i-lucide-git-branch" },
+	{ label: "Text", value: "text", icon: "i-lucide-align-left" },
+];
+
 const Header = ({
 	models,
 	activeModel,
@@ -43,11 +53,28 @@ const Header = ({
 				size="sm"
 				value={view}
 				onChange={(value) => onViewChange(value as "chat" | "diagram" | "text")}
-				data={[
-					{ label: "Chat", value: "chat" },
-					{ label: "Diagram", value: "diagram" },
-					{ label: "Text", value: "text" },
-				]}
+				data={viewOptions.map((option) => ({
+					value: option.value,
+					label: (
+						<span className="flex items-center gap-2 text-sm font-medium">
+							<span
+								className={`w-4 h-4 ${option.icon}`}
+								aria-hidden="true"
+							/>
+							{option.label}
+						</span>
+					),
+				}))}
+				withItemsBorders={false}
+				radius="xl"
+				classNames={{
+					root: "rounded-full bg-slate-100/80 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800 p-1",
+					indicator:
+						"rounded-full bg-white dark:bg-slate-800 text-slate-900 dark:text-white shadow-sm",
+					control:
+						"text-slate-500 dark:text-slate-400 data-[active=true]:text-slate-900 dark:data-[active=true]:text-white transition-colors",
+					label: "px-3 py-1.5",
+				}}
 				aria-label="View switch"
 			/>
 		</div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,12 @@
 import { SegmentedControl, Select, UnstyledButton } from "@mantine/core";
+import type { AppView } from "../types";
 
 interface HeaderProps {
 	models: Array<{ id: string; name?: string | null }>;
 	activeModel: string | null;
 	onModelChange: (value: string | null) => void;
-	view: "chat" | "diagram" | "text";
-	onViewChange: (value: "chat" | "diagram" | "text") => void;
+	view: AppView;
+	onViewChange: (value: AppView) => void;
 	onClear: () => void;
 	onImport: () => void;
 	onExport: () => void;
@@ -14,7 +15,7 @@ interface HeaderProps {
 
 const viewOptions: Array<{
 	label: string;
-	value: "chat" | "diagram" | "text";
+	value: AppView;
 	icon: string;
 }> = [
 	{ label: "Chat", value: "chat", icon: "i-lucide-message-square" },
@@ -52,7 +53,7 @@ const Header = ({
 			<SegmentedControl
 				size="sm"
 				value={view}
-				onChange={(value) => onViewChange(value as "chat" | "diagram" | "text")}
+				onChange={(value) => onViewChange(value as AppView)}
 				data={viewOptions.map((option) => ({
 					value: option.value,
 					label: (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,8 +4,8 @@ interface HeaderProps {
 	models: Array<{ id: string; name?: string | null }>;
 	activeModel: string | null;
 	onModelChange: (value: string | null) => void;
-	view: "chat" | "diagram";
-	onViewChange: (value: "chat" | "diagram") => void;
+	view: "chat" | "diagram" | "text";
+	onViewChange: (value: "chat" | "diagram" | "text") => void;
 	onClear: () => void;
 	onImport: () => void;
 	onExport: () => void;
@@ -42,10 +42,11 @@ const Header = ({
 			<SegmentedControl
 				size="sm"
 				value={view}
-				onChange={(value) => onViewChange(value as "chat" | "diagram")}
+				onChange={(value) => onViewChange(value as "chat" | "diagram" | "text")}
 				data={[
 					{ label: "Chat", value: "chat" },
 					{ label: "Diagram", value: "diagram" },
+					{ label: "Text", value: "text" },
 				]}
 				aria-label="View switch"
 			/>

--- a/src/components/TextCompletionView.tsx
+++ b/src/components/TextCompletionView.tsx
@@ -1,0 +1,59 @@
+import { Textarea } from "@mantine/core";
+import { twJoin } from "tailwind-merge";
+
+interface TextCompletionViewProps {
+	value: string;
+	isGenerating: boolean;
+	onChange: (value: string) => void;
+	onPredict: () => void;
+	onCancel: () => void;
+}
+
+const TextCompletionView = ({
+	value,
+	isGenerating,
+	onChange,
+	onPredict,
+	onCancel,
+}: TextCompletionViewProps) => (
+	<div className="flex flex-1 flex-col gap-4 px-4 py-2">
+		<Textarea
+			className="flex-1"
+			minRows={8}
+			autosize
+			value={value}
+			onChange={(event) => {
+				onChange(event.target.value);
+			}}
+			placeholder="Provide some starter text and let the model continue it..."
+		/>
+		<div className="flex gap-2">
+			<button
+				type="button"
+				className={twJoin(
+					"rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors",
+					"hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2",
+					isGenerating ? "cursor-not-allowed opacity-60" : "",
+				)}
+				onClick={onPredict}
+				disabled={isGenerating}
+			>
+				Predict
+			</button>
+			<button
+				type="button"
+				className={twJoin(
+					"rounded border border-slate-200 bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 transition-colors",
+					"hover:bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2",
+					!isGenerating ? "cursor-not-allowed opacity-60" : "",
+				)}
+				onClick={onCancel}
+				disabled={!isGenerating}
+			>
+				Cancel
+			</button>
+		</div>
+	</div>
+);
+
+export default TextCompletionView;

--- a/src/components/TextCompletionView.tsx
+++ b/src/components/TextCompletionView.tsx
@@ -1,5 +1,4 @@
-import { Textarea } from "@mantine/core";
-import { twJoin } from "tailwind-merge";
+import { Button, Textarea } from "@mantine/core";
 
 interface TextCompletionViewProps {
 	value: string;
@@ -16,42 +15,43 @@ const TextCompletionView = ({
 	onPredict,
 	onCancel,
 }: TextCompletionViewProps) => (
-	<div className="flex flex-1 flex-col gap-4 px-4 py-2">
-		<Textarea
-			className="flex-1"
-			minRows={8}
-			autosize
-			value={value}
-			onChange={(event) => {
-				onChange(event.target.value);
-			}}
-			placeholder="Provide some starter text and let the model continue it..."
-		/>
-		<div className="flex gap-2">
-			<button
-				type="button"
-				className={twJoin(
-					"rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 transition-colors",
-					"hover:bg-slate-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2",
-					isGenerating ? "cursor-not-allowed opacity-60" : "",
-				)}
-				onClick={onPredict}
-				disabled={isGenerating}
+	<div className="flex flex-1 flex-col gap-6 px-6 py-4">
+		<div className="flex-1 rounded-2xl bg-slate-50/90 p-4 backdrop-blur dark:bg-slate-900/40">
+			<Textarea
+				className="h-full"
+				minRows={12}
+				autosize
+				size="lg"
+				value={value}
+				onChange={(event) => {
+					onChange(event.target.value);
+				}}
+					placeholder="Provide a seed paragraph and let the model continue it…"
+					classNames={{
+						input: "h-full min-h-[18rem] resize-none border-none bg-transparent text-lg leading-relaxed text-slate-900 placeholder:text-slate-400 focus:outline-none dark:text-slate-100",
+					}}
+				/>
+		</div>
+		<div className="flex justify-end">
+			<Button
+				radius="xl"
+				size="md"
+				variant={isGenerating ? "light" : "filled"}
+				color={isGenerating ? "red" : "blue"}
+				onClick={isGenerating ? onCancel : onPredict}
+				leftSection={
+					<span
+						className={
+							isGenerating
+								? "w-4 h-4 i-lucide-loader-2 animate-spin"
+								: "w-4 h-4 i-lucide-wand-2"
+						}
+						aria-hidden="true"
+					/>
+				}
 			>
-				Predict
-			</button>
-			<button
-				type="button"
-				className={twJoin(
-					"rounded border border-slate-200 bg-slate-100 px-4 py-2 text-sm font-medium text-slate-600 transition-colors",
-					"hover:bg-slate-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-500 focus-visible:ring-offset-2",
-					!isGenerating ? "cursor-not-allowed opacity-60" : "",
-				)}
-				onClick={onCancel}
-				disabled={!isGenerating}
-			>
-				Cancel
-			</button>
+				{isGenerating ? "Stop" : "Predict"}
+			</Button>
 		</div>
 	</div>
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,12 @@
+export type AppView = "chat" | "diagram" | "text";
+
+export interface MessageMetadata {
+	uuid: string;
+}
+
 export interface Message {
-	role: string;
+	role: "system" | "user" | "assistant" | "tool";
 	content: string;
 	reasoning_content?: string;
-	_metadata: {
-		uuid: string;
-	};
-	_abortController?: AbortController;
+	_metadata: MessageMetadata;
 }


### PR DESCRIPTION
## Summary
- add a text completion view with streaming Predict/Cancel controls backed by the Responses API
- separate text-mode state from chat and update the view switcher to include the new mode
- ensure model lists default safely and clean up streaming controllers when navigating away

## Testing
- bunx tsc --noEmit *(fails: existing type errors in src/tree/useConversationTree.ts)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912b79c8e908324815dc3e8bc1fd0eb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Text Completion view alongside Chat and Diagram with a large editable text area.
  * Streaming text generation with Predict/Stop controls and visible generating state.

* **Bug Fixes / Stability**
  * In-flight text generation is aborted on view change or when clearing; text is preserved or cleared appropriately.

* **UI**
  * Header now lets you switch to the Text view; Chat and Diagram workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->