### PR TITLE
feat: make chat edits immutable and simplify diagram controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,6 @@ const App = () => {
 		setNodeText,
 		setNodeStatus,
 		cloneNode,
-		splitBranch,
 		predecessorOf,
 		compilePathTo,
 		activeTail,
@@ -152,7 +151,6 @@ const App = () => {
 			setNodeText: state.setNodeText,
 			setNodeStatus: state.setNodeStatus,
 			cloneNode: state.cloneNode,
-			splitBranch: state.splitBranch,
 			predecessorOf: state.predecessorOf,
 			compilePathTo: state.compilePathTo,
 			activeTail: state.activeTail,
@@ -280,16 +278,14 @@ const App = () => {
 		setIsGenerating(false);
 	};
 
-	const handleDuplicateFromNode = (nodeId: string) => {
-		const newId = cloneNode(nodeId);
-		if (!newId) {
+	const handleEditMessage = (nodeId: string, content: string) => {
+		const clonedId = cloneNode(nodeId);
+		if (!clonedId) {
 			return;
 		}
-		handleActivateThread(newId);
-	};
-
-	const handleEditMessage = (nodeId: string, content: string) => {
-		setEditingNodeId(nodeId);
+		setNodeStatus(clonedId, "draft");
+		setActiveTarget(clonedId);
+		setEditingNodeId(clonedId);
 		setPrompt(content);
 	};
 
@@ -328,8 +324,7 @@ const App = () => {
 			setEditingNodeId(undefined);
 			setPrompt("");
 		}
-		splitBranch(nodeId);
-		handleActivateThread(prevId);
+		setActiveTarget(prevId);
 	};
 
 	const handleSend = async () => {
@@ -518,7 +513,6 @@ const App = () => {
 								}
 								onDelete={() => handleDeleteMessage(message._metadata.uuid)}
 								onDetach={() => handleDetachMessage(message._metadata.uuid)}
-								onBranch={() => handleActivateThread(message._metadata.uuid)}
 							/>
 						))}
 					</div>
@@ -587,8 +581,7 @@ const App = () => {
 				<div className="flex-1 overflow-hidden px-2 py-2">
 					<DiagramView
 						onNodeDoubleClick={handleActivateThread}
-						onBranchFromNode={handleActivateThread}
-						onDuplicateFromNode={handleDuplicateFromNode}
+						onSetActiveNode={handleActivateThread}
 					/>
 				</div>
 			)}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,6 +278,14 @@ const App = () => {
 		setIsGenerating(false);
 	};
 
+	const handleDuplicateFromNode = (nodeId: string) => {
+		const newId = cloneNode(nodeId);
+		if (!newId) {
+			return;
+		}
+		handleActivateThread(newId);
+	};
+
 	const handleEditMessage = (nodeId: string, content: string) => {
 		const clonedId = cloneNode(nodeId);
 		if (!clonedId) {
@@ -582,6 +590,7 @@ const App = () => {
 					<DiagramView
 						onNodeDoubleClick={handleActivateThread}
 						onSetActiveNode={handleActivateThread}
+						onDuplicateFromNode={handleDuplicateFromNode}
 					/>
 				</div>
 			)}

--- a/src/components/DiagramView.tsx
+++ b/src/components/DiagramView.tsx
@@ -1,11 +1,22 @@
 import {
 	Background,
+	type Connection,
 	type Edge,
+	Handle,
 	MiniMap,
 	type Node,
+	type NodeProps,
+	Position,
 	ReactFlow,
 } from "@xyflow/react";
-import { useEffect, useMemo, useState } from "react";
+import {
+	type CSSProperties,
+	type ReactNode,
+	useCallback,
+	useEffect,
+	useMemo,
+	useState,
+} from "react";
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import { twJoin } from "tailwind-merge";
@@ -28,12 +39,42 @@ const boxSize = {
 const columnGap = 64;
 const rowGap = 80;
 
-const nodeStyleBase = {
+type DiagramNodeData = {
+	label: ReactNode;
+	style: CSSProperties;
+};
+
+const nodeStyleBase: CSSProperties = {
 	border: "1px solid #e2e8f0",
 	borderRadius: 8,
 	padding: 8,
 	background: "#fff",
 	width: boxSize.width,
+	boxSizing: "border-box",
+};
+
+const DiagramNode = ({ data }: NodeProps<DiagramNodeData>) => {
+	return (
+		<div className="relative" style={data.style}>
+			<Handle
+				type="target"
+				position={Position.Top}
+				className="h-3 w-3 border border-white bg-slate-400 shadow-sm shadow-slate-400/40"
+				style={{ borderRadius: "9999px" }}
+			/>
+			<div>{data.label}</div>
+			<Handle
+				type="source"
+				position={Position.Bottom}
+				className="h-3 w-3 border border-white bg-slate-400 shadow-sm shadow-slate-400/40"
+				style={{ borderRadius: "9999px" }}
+			/>
+		</div>
+	);
+};
+
+const diagramNodeTypes = {
+	diagram: DiagramNode,
 };
 
 const DiagramView = ({
@@ -45,12 +86,20 @@ const DiagramView = ({
 		edges: treeEdges,
 		activeTargetId,
 		compileActive,
+		canReparent,
+		reparentNode,
+		cloneNode,
+		removeNode,
 	} = useConversationTree(
 		useShallow((state) => ({
 			nodes: state.nodes,
 			edges: state.edges,
 			activeTargetId: state.activeTargetId,
 			compileActive: state.compileActive,
+			canReparent: state.canReparent,
+			reparentNode: state.reparentNode,
+			cloneNode: state.cloneNode,
+			removeNode: state.removeNode,
 		})),
 	);
 
@@ -167,7 +216,7 @@ const DiagramView = ({
 		return depthMap;
 	}, [treeNodes]);
 
-	const [layoutNodes, setLayoutNodes] = useState<Node[]>([]);
+	const [layoutNodes, setLayoutNodes] = useState<Node<DiagramNodeData>[]>([]);
 	const [layoutEdges, setLayoutEdges] = useState<Edge[]>([]);
 	const [contextMenuNodeId, setContextMenuNodeId] = useState<string | null>(
 		null,
@@ -208,50 +257,54 @@ const DiagramView = ({
 					if (cancelled) {
 						return;
 					}
-					const nodes: Node[] = (result.children ?? []).map((child) => {
-						const dataNode = treeNodes[child.id];
-						if (!dataNode) {
+					const nodes: Node<DiagramNodeData>[] = (result.children ?? []).map(
+						(child) => {
+							const dataNode = treeNodes[child.id];
+							if (!dataNode) {
+								return {
+									id: child.id,
+									type: "diagram",
+									position: { x: child.x ?? 0, y: child.y ?? 0 },
+									data: { label: child.id, style: { ...nodeStyleBase } },
+								} satisfies Node<DiagramNodeData>;
+							}
+
+							const label = (
+								<div className="flex items-start gap-2">
+									<div className="min-w-0">
+										<p className="text-xs font-mono uppercase text-slate-500">
+											{dataNode.role}
+										</p>
+										<p className="mt-1 text-sm font-medium leading-snug text-slate-800 line-clamp-3">
+											{dataNode.text}
+										</p>
+									</div>
+								</div>
+							);
+
+							const isActive = activePathIds.nodes.has(child.id);
+							const style = {
+								...nodeStyleBase,
+								border: isActive ? "2px solid #2563eb" : "1px solid #e2e8f0",
+								opacity: isActive ? 1 : 0.7,
+							};
+
 							return {
 								id: child.id,
-								position: { x: child.x ?? 0, y: child.y ?? 0 },
-								data: { label: child.id },
-							} satisfies Node;
-						}
-
-						const label = (
-							<div className="flex items-start gap-2">
-								<div className="min-w-0">
-									<p className="text-xs font-mono uppercase text-slate-500">
-										{dataNode.role}
-									</p>
-									<p className="mt-1 text-sm font-medium leading-snug text-slate-800 line-clamp-3">
-										{dataNode.text}
-									</p>
-								</div>
-							</div>
-						);
-
-						const isActive = activePathIds.nodes.has(child.id);
-						const style = {
-							...nodeStyleBase,
-							border: isActive ? "2px solid #2563eb" : "1px solid #e2e8f0",
-							opacity: isActive ? 1 : 0.7,
-						};
-
-						return {
-							id: child.id,
-							position: {
-								x:
-									(laneAssignments.get(child.id) ?? laneAssignments.size) *
-									(boxSize.width + columnGap),
-								y:
-									child.y ??
-									(depthByNode.get(child.id) ?? 0) * (boxSize.height + rowGap),
-							},
-							data: { label },
-							style,
-						} satisfies Node;
-					});
+								type: "diagram",
+								position: {
+									x:
+										(laneAssignments.get(child.id) ?? laneAssignments.size) *
+										(boxSize.width + columnGap),
+									y:
+										child.y ??
+										(depthByNode.get(child.id) ?? 0) *
+											(boxSize.height + rowGap),
+								},
+								data: { label, style },
+							} satisfies Node<DiagramNodeData>;
+						},
+					);
 
 					const edgesStyled: Edge[] = (result.edges ?? []).flatMap((edge) => {
 						const source = edge.sources?.[0];
@@ -298,6 +351,57 @@ const DiagramView = ({
 		depthByNode,
 	]);
 
+	const handleDuplicateNode = useCallback(
+		(nodeId: string) => {
+			const newId = cloneNode(nodeId);
+			if (!newId) {
+				return;
+			}
+			onSetActiveNode?.(newId);
+		},
+		[cloneNode, onSetActiveNode],
+	);
+
+	const handleRemoveNode = useCallback(
+		(nodeId: string) => {
+			removeNode(nodeId);
+		},
+		[removeNode],
+	);
+
+	const handleIsValidConnection = useCallback(
+		(connection: Connection) => {
+			const sourceId = connection.source;
+			const targetId = connection.target;
+			if (!sourceId || !targetId) {
+				return false;
+			}
+			if (!treeNodes[sourceId] || !treeNodes[targetId]) {
+				return false;
+			}
+			if (treeNodes[targetId].parentId === sourceId) {
+				return false;
+			}
+			return canReparent(sourceId, targetId);
+		},
+		[treeNodes, canReparent],
+	);
+
+	const handleConnect = useCallback(
+		(connection: Connection) => {
+			if (!handleIsValidConnection(connection)) {
+				return;
+			}
+			const sourceId = connection.source;
+			const targetId = connection.target;
+			if (!sourceId || !targetId) {
+				return;
+			}
+			reparentNode(targetId, sourceId);
+		},
+		[handleIsValidConnection, reparentNode],
+	);
+
 	const hasGraphData =
 		layoutNodes.length > 0 || Object.keys(treeNodes).length > 0;
 
@@ -310,13 +414,19 @@ const DiagramView = ({
 						setContextMenuNodeId(null);
 					}}
 					onSetActive={onSetActiveNode}
+					onDuplicate={handleDuplicateNode}
+					onRemove={handleRemoveNode}
 				>
 					<ReactFlow
 						nodes={layoutNodes}
 						edges={layoutEdges}
+						nodeTypes={diagramNodeTypes}
 						fitView
 						nodesDraggable={false}
+						nodesConnectable
 						zoomOnDoubleClick={false}
+						onConnect={handleConnect}
+						isValidConnection={handleIsValidConnection}
 						onPaneClick={() => {
 							setContextMenuNodeId(null);
 						}}

--- a/src/components/DiagramView.tsx
+++ b/src/components/DiagramView.tsx
@@ -2,21 +2,11 @@ import {
 	Background,
 	type Connection,
 	type Edge,
-	Handle,
 	MiniMap,
 	type Node,
-	type NodeProps,
-	Position,
 	ReactFlow,
 } from "@xyflow/react";
-import {
-	type CSSProperties,
-	type ReactNode,
-	useCallback,
-	useEffect,
-	useMemo,
-	useState,
-} from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import { twJoin } from "tailwind-merge";
@@ -27,6 +17,7 @@ import NodeContextMenu from "./NodeContextMenu";
 interface DiagramViewProps {
 	onNodeDoubleClick?: (nodeId: string) => void;
 	onSetActiveNode?: (nodeId: string) => void;
+	onDuplicateFromNode?: (nodeId: string) => void;
 }
 
 const elk = new ELK();
@@ -39,47 +30,18 @@ const boxSize = {
 const columnGap = 64;
 const rowGap = 80;
 
-type DiagramNodeData = {
-	label: ReactNode;
-	style: CSSProperties;
-};
-
-const nodeStyleBase: CSSProperties = {
+const nodeStyleBase = {
 	border: "1px solid #e2e8f0",
 	borderRadius: 8,
 	padding: 8,
 	background: "#fff",
 	width: boxSize.width,
-	boxSizing: "border-box",
-};
-
-const DiagramNode = ({ data }: NodeProps<DiagramNodeData>) => {
-	return (
-		<div className="relative" style={data.style}>
-			<Handle
-				type="target"
-				position={Position.Top}
-				className="h-3 w-3 border border-white bg-slate-400 shadow-sm shadow-slate-400/40"
-				style={{ borderRadius: "9999px" }}
-			/>
-			<div>{data.label}</div>
-			<Handle
-				type="source"
-				position={Position.Bottom}
-				className="h-3 w-3 border border-white bg-slate-400 shadow-sm shadow-slate-400/40"
-				style={{ borderRadius: "9999px" }}
-			/>
-		</div>
-	);
-};
-
-const diagramNodeTypes = {
-	diagram: DiagramNode,
 };
 
 const DiagramView = ({
 	onNodeDoubleClick,
 	onSetActiveNode,
+	onDuplicateFromNode,
 }: DiagramViewProps) => {
 	const {
 		nodes: treeNodes,
@@ -88,7 +50,7 @@ const DiagramView = ({
 		compileActive,
 		canReparent,
 		reparentNode,
-		cloneNode,
+		splitBranch,
 		removeNode,
 	} = useConversationTree(
 		useShallow((state) => ({
@@ -98,7 +60,7 @@ const DiagramView = ({
 			compileActive: state.compileActive,
 			canReparent: state.canReparent,
 			reparentNode: state.reparentNode,
-			cloneNode: state.cloneNode,
+			splitBranch: state.splitBranch,
 			removeNode: state.removeNode,
 		})),
 	);
@@ -216,11 +178,12 @@ const DiagramView = ({
 		return depthMap;
 	}, [treeNodes]);
 
-	const [layoutNodes, setLayoutNodes] = useState<Node<DiagramNodeData>[]>([]);
+	const [layoutNodes, setLayoutNodes] = useState<Node[]>([]);
 	const [layoutEdges, setLayoutEdges] = useState<Edge[]>([]);
 	const [contextMenuNodeId, setContextMenuNodeId] = useState<string | null>(
 		null,
 	);
+	const pendingNodeRemovalsRef = useRef<Set<string>>(new Set());
 
 	useEffect(() => {
 		const children = Object.values(treeNodes).map((node) => ({
@@ -257,54 +220,50 @@ const DiagramView = ({
 					if (cancelled) {
 						return;
 					}
-					const nodes: Node<DiagramNodeData>[] = (result.children ?? []).map(
-						(child) => {
-							const dataNode = treeNodes[child.id];
-							if (!dataNode) {
-								return {
-									id: child.id,
-									type: "diagram",
-									position: { x: child.x ?? 0, y: child.y ?? 0 },
-									data: { label: child.id, style: { ...nodeStyleBase } },
-								} satisfies Node<DiagramNodeData>;
-							}
-
-							const label = (
-								<div className="flex items-start gap-2">
-									<div className="min-w-0">
-										<p className="text-xs font-mono uppercase text-slate-500">
-											{dataNode.role}
-										</p>
-										<p className="mt-1 text-sm font-medium leading-snug text-slate-800 line-clamp-3">
-											{dataNode.text}
-										</p>
-									</div>
-								</div>
-							);
-
-							const isActive = activePathIds.nodes.has(child.id);
-							const style = {
-								...nodeStyleBase,
-								border: isActive ? "2px solid #2563eb" : "1px solid #e2e8f0",
-								opacity: isActive ? 1 : 0.7,
-							};
-
+					const nodes: Node[] = (result.children ?? []).map((child) => {
+						const dataNode = treeNodes[child.id];
+						if (!dataNode) {
 							return {
 								id: child.id,
-								type: "diagram",
-								position: {
-									x:
-										(laneAssignments.get(child.id) ?? laneAssignments.size) *
-										(boxSize.width + columnGap),
-									y:
-										child.y ??
-										(depthByNode.get(child.id) ?? 0) *
-											(boxSize.height + rowGap),
-								},
-								data: { label, style },
-							} satisfies Node<DiagramNodeData>;
-						},
-					);
+								position: { x: child.x ?? 0, y: child.y ?? 0 },
+								data: { label: child.id },
+							} satisfies Node;
+						}
+
+						const label = (
+							<div className="flex items-start gap-2">
+								<div className="min-w-0">
+									<p className="text-xs font-mono uppercase text-slate-500">
+										{dataNode.role}
+									</p>
+									<p className="mt-1 text-sm font-medium leading-snug text-slate-800 line-clamp-3">
+										{dataNode.text}
+									</p>
+								</div>
+							</div>
+						);
+
+						const isActive = activePathIds.nodes.has(child.id);
+						const style = {
+							...nodeStyleBase,
+							border: isActive ? "2px solid #2563eb" : "1px solid #e2e8f0",
+							opacity: isActive ? 1 : 0.7,
+						};
+
+						return {
+							id: child.id,
+							position: {
+								x:
+									(laneAssignments.get(child.id) ?? laneAssignments.size) *
+									(boxSize.width + columnGap),
+								y:
+									child.y ??
+									(depthByNode.get(child.id) ?? 0) * (boxSize.height + rowGap),
+							},
+							data: { label },
+							style,
+						} satisfies Node;
+					});
 
 					const edgesStyled: Edge[] = (result.edges ?? []).flatMap((edge) => {
 						const source = edge.sources?.[0];
@@ -351,57 +310,6 @@ const DiagramView = ({
 		depthByNode,
 	]);
 
-	const handleDuplicateNode = useCallback(
-		(nodeId: string) => {
-			const newId = cloneNode(nodeId);
-			if (!newId) {
-				return;
-			}
-			onSetActiveNode?.(newId);
-		},
-		[cloneNode, onSetActiveNode],
-	);
-
-	const handleRemoveNode = useCallback(
-		(nodeId: string) => {
-			removeNode(nodeId);
-		},
-		[removeNode],
-	);
-
-	const handleIsValidConnection = useCallback(
-		(connection: Connection) => {
-			const sourceId = connection.source;
-			const targetId = connection.target;
-			if (!sourceId || !targetId) {
-				return false;
-			}
-			if (!treeNodes[sourceId] || !treeNodes[targetId]) {
-				return false;
-			}
-			if (treeNodes[targetId].parentId === sourceId) {
-				return false;
-			}
-			return canReparent(sourceId, targetId);
-		},
-		[treeNodes, canReparent],
-	);
-
-	const handleConnect = useCallback(
-		(connection: Connection) => {
-			if (!handleIsValidConnection(connection)) {
-				return;
-			}
-			const sourceId = connection.source;
-			const targetId = connection.target;
-			if (!sourceId || !targetId) {
-				return;
-			}
-			reparentNode(targetId, sourceId);
-		},
-		[handleIsValidConnection, reparentNode],
-	);
-
 	const hasGraphData =
 		layoutNodes.length > 0 || Object.keys(treeNodes).length > 0;
 
@@ -414,19 +322,18 @@ const DiagramView = ({
 						setContextMenuNodeId(null);
 					}}
 					onSetActive={onSetActiveNode}
-					onDuplicate={handleDuplicateNode}
-					onRemove={handleRemoveNode}
+					onDuplicate={onDuplicateFromNode}
+					onRemove={(nodeId) => {
+						removeNode(nodeId);
+					}}
 				>
 					<ReactFlow
 						nodes={layoutNodes}
 						edges={layoutEdges}
-						nodeTypes={diagramNodeTypes}
 						fitView
-						nodesDraggable={false}
 						nodesConnectable
+						nodesDraggable={false}
 						zoomOnDoubleClick={false}
-						onConnect={handleConnect}
-						isValidConnection={handleIsValidConnection}
 						onPaneClick={() => {
 							setContextMenuNodeId(null);
 						}}
@@ -441,6 +348,34 @@ const DiagramView = ({
 						onNodeContextMenu={(event, node) => {
 							event.preventDefault();
 							setContextMenuNodeId(node.id);
+						}}
+						onConnect={(connection: Connection) => {
+							if (!connection.source || !connection.target) {
+								return;
+							}
+							if (canReparent(connection.source, connection.target)) {
+								reparentNode(connection.target, connection.source);
+							}
+						}}
+						onEdgesDelete={(edgesDeleted) => {
+							edgesDeleted.forEach((edge) => {
+								const pendingRemovals = pendingNodeRemovalsRef.current;
+								if (edge.target && !pendingRemovals.has(edge.target)) {
+									splitBranch(edge.target);
+								}
+							});
+						}}
+						onNodesDelete={(nodesDeleted) => {
+							nodesDeleted.forEach((node) => {
+								removeNode(node.id);
+							});
+							pendingNodeRemovalsRef.current.clear();
+						}}
+						onBeforeDelete={async ({ nodes }) => {
+							pendingNodeRemovalsRef.current = new Set(
+								nodes.map((node) => node.id),
+							);
+							return true;
 						}}
 					>
 						<Background />

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -64,18 +64,24 @@ const MessageItem = ({
 							<UnstyledButton
 								className="i-lucide-copy text-slate-400 hover:text-slate-600 transition"
 								onClick={handleCopy}
+								title="Copy message content"
 							/>
 							<UnstyledButton
 								className="i-lucide-edit text-slate-400 hover:text-slate-600 transition"
 								onClick={onEdit}
+								title="Edit message"
 							/>
 							<UnstyledButton
 								className="i-lucide-unlink text-slate-400 hover:text-slate-600 transition"
 								onClick={onDetach}
+								title="Move cursor to parent"
 							/>
 							<Popover width={200} position="bottom" withArrow>
 								<Popover.Target>
-									<UnstyledButton className="i-lucide-trash text-slate-400 hover:text-slate-600 transition" />
+									<UnstyledButton
+										className="i-lucide-trash text-slate-400 hover:text-slate-600 transition"
+										title="Delete message"
+									/>
 								</Popover.Target>
 								<Popover.Dropdown>
 									<div className="flex flex-col">

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -13,7 +13,6 @@ interface MessageItemProps {
 	onEdit: () => void;
 	onDelete: () => void;
 	onDetach: () => void;
-	onBranch: () => void;
 }
 
 const MessageItem = ({
@@ -24,7 +23,6 @@ const MessageItem = ({
 	onEdit,
 	onDelete,
 	onDetach,
-	onBranch,
 }: MessageItemProps) => {
 	const [isHovered, setIsHovered] = useState(false);
 	const [hasBeenClicked, setHasBeenClicked] = useState(false);
@@ -71,6 +69,10 @@ const MessageItem = ({
 								className="i-lucide-edit text-slate-400 hover:text-slate-600 transition"
 								onClick={onEdit}
 							/>
+							<UnstyledButton
+								className="i-lucide-unlink text-slate-400 hover:text-slate-600 transition"
+								onClick={onDetach}
+							/>
 							<Popover width={200} position="bottom" withArrow>
 								<Popover.Target>
 									<UnstyledButton className="i-lucide-trash text-slate-400 hover:text-slate-600 transition" />
@@ -87,15 +89,6 @@ const MessageItem = ({
 									</div>
 								</Popover.Dropdown>
 							</Popover>
-							<UnstyledButton
-								className="i-lucide-unlink text-slate-400 hover:text-slate-600 transition"
-								onClick={onDetach}
-							/>
-							<UnstyledButton
-								className="i-lucide-git-branch-plus text-slate-400 hover:text-slate-600 transition"
-								title="Branch from here"
-								onClick={onBranch}
-							/>
 						</>
 					)}
 				</div>

--- a/src/components/NodeContextMenu.tsx
+++ b/src/components/NodeContextMenu.tsx
@@ -5,6 +5,8 @@ interface NodeContextMenuProps {
 	targetId: string | null;
 	onClose: () => void;
 	onSetActive?: (nodeId: string) => void;
+	onDuplicate?: (nodeId: string) => void;
+	onRemove?: (nodeId: string) => void;
 	children: ReactNode;
 }
 
@@ -15,6 +17,8 @@ const NodeContextMenu = ({
 	targetId,
 	onClose,
 	onSetActive,
+	onDuplicate,
+	onRemove,
 	children,
 }: NodeContextMenuProps) => {
 	const open = Boolean(targetId);
@@ -42,12 +46,35 @@ const NodeContextMenu = ({
 			<ContextMenu.Portal>
 				<ContextMenu.Positioner className="outline-none">
 					<ContextMenu.Popup className="origin-[var(--transform-origin)] min-w-[8rem] rounded-xl border border-slate-300 bg-white p-0.5 shadow-[0_12px_40px_rgba(15,23,42,0.25)] transition-[opacity,transform] duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:shadow-[0_18px_45px_rgba(0,0,0,0.55)]">
-						<ContextMenu.Item
-							className={menuItemClassName}
-							onClick={invoke(onSetActive)}
-						>
-							<span>Set active cursor here</span>
-						</ContextMenu.Item>
+						{onSetActive && (
+							<ContextMenu.Item
+								className={menuItemClassName}
+								onClick={invoke(onSetActive)}
+							>
+								<span>Set active cursor here</span>
+							</ContextMenu.Item>
+						)}
+						{(onDuplicate || onRemove) && (
+							<ContextMenu.Separator className="my-0.5 h-px bg-slate-200" />
+						)}
+						{onDuplicate && (
+							<ContextMenu.Item
+								className={menuItemClassName}
+								onClick={invoke(onDuplicate)}
+							>
+								<span>Duplicate node</span>
+							</ContextMenu.Item>
+						)}
+						{onRemove && (
+							<ContextMenu.Item
+								className={menuItemClassName.concat(
+									" text-red-600 data-[highlighted]:bg-red-600 data-[highlighted]:text-white",
+								)}
+								onClick={invoke(onRemove)}
+							>
+								<span>Remove node</span>
+							</ContextMenu.Item>
+						)}
 					</ContextMenu.Popup>
 				</ContextMenu.Positioner>
 			</ContextMenu.Portal>

--- a/src/components/NodeContextMenu.tsx
+++ b/src/components/NodeContextMenu.tsx
@@ -4,9 +4,7 @@ import type { ReactNode } from "react";
 interface NodeContextMenuProps {
 	targetId: string | null;
 	onClose: () => void;
-	onBranch?: (nodeId: string) => void;
-	onDuplicate?: (nodeId: string) => void;
-	onRemove?: (nodeId: string) => void;
+	onSetActive?: (nodeId: string) => void;
 	children: ReactNode;
 }
 
@@ -16,9 +14,7 @@ const menuItemClassName =
 const NodeContextMenu = ({
 	targetId,
 	onClose,
-	onBranch,
-	onDuplicate,
-	onRemove,
+	onSetActive,
 	children,
 }: NodeContextMenuProps) => {
 	const open = Boolean(targetId);
@@ -48,22 +44,9 @@ const NodeContextMenu = ({
 					<ContextMenu.Popup className="origin-[var(--transform-origin)] min-w-[8rem] rounded-xl border border-slate-300 bg-white p-0.5 shadow-[0_12px_40px_rgba(15,23,42,0.25)] transition-[opacity,transform] duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:shadow-[0_18px_45px_rgba(0,0,0,0.55)]">
 						<ContextMenu.Item
 							className={menuItemClassName}
-							onClick={invoke(onBranch)}
+							onClick={invoke(onSetActive)}
 						>
-							<span>Branch from here</span>
-						</ContextMenu.Item>
-						<ContextMenu.Item
-							className={menuItemClassName}
-							onClick={invoke(onDuplicate)}
-						>
-							<span>Duplicate here</span>
-						</ContextMenu.Item>
-						<ContextMenu.Separator className="mx-2 my-1 h-px bg-slate-200 dark:bg-slate-700" />
-						<ContextMenu.Item
-							className={`${menuItemClassName} text-rose-600 data-[highlighted]:text-white`}
-							onClick={invoke(onRemove)}
-						>
-							<span>Remove node</span>
+							<span>Set active cursor here</span>
 						</ContextMenu.Item>
 					</ContextMenu.Popup>
 				</ContextMenu.Positioner>

--- a/src/components/NodeContextMenu.tsx
+++ b/src/components/NodeContextMenu.tsx
@@ -46,35 +46,25 @@ const NodeContextMenu = ({
 			<ContextMenu.Portal>
 				<ContextMenu.Positioner className="outline-none">
 					<ContextMenu.Popup className="origin-[var(--transform-origin)] min-w-[8rem] rounded-xl border border-slate-300 bg-white p-0.5 shadow-[0_12px_40px_rgba(15,23,42,0.25)] transition-[opacity,transform] duration-150 data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:shadow-[0_18px_45px_rgba(0,0,0,0.55)]">
-						{onSetActive && (
-							<ContextMenu.Item
-								className={menuItemClassName}
-								onClick={invoke(onSetActive)}
-							>
-								<span>Set active cursor here</span>
-							</ContextMenu.Item>
-						)}
-						{(onDuplicate || onRemove) && (
-							<ContextMenu.Separator className="my-0.5 h-px bg-slate-200" />
-						)}
-						{onDuplicate && (
-							<ContextMenu.Item
-								className={menuItemClassName}
-								onClick={invoke(onDuplicate)}
-							>
-								<span>Duplicate node</span>
-							</ContextMenu.Item>
-						)}
-						{onRemove && (
-							<ContextMenu.Item
-								className={menuItemClassName.concat(
-									" text-red-600 data-[highlighted]:bg-red-600 data-[highlighted]:text-white",
-								)}
-								onClick={invoke(onRemove)}
-							>
-								<span>Remove node</span>
-							</ContextMenu.Item>
-						)}
+						<ContextMenu.Item
+							className={menuItemClassName}
+							onClick={invoke(onSetActive)}
+						>
+							<span>Set active cursor here</span>
+						</ContextMenu.Item>
+						<ContextMenu.Item
+							className={menuItemClassName}
+							onClick={invoke(onDuplicate)}
+						>
+							<span>Duplicate node</span>
+						</ContextMenu.Item>
+						<ContextMenu.Separator className="mx-2 my-1 h-px bg-slate-200 dark:bg-slate-700" />
+						<ContextMenu.Item
+							className={`${menuItemClassName} text-rose-600 data-[highlighted]:text-white`}
+							onClick={invoke(onRemove)}
+						>
+							<span>Remove node</span>
+						</ContextMenu.Item>
 					</ContextMenu.Popup>
 				</ContextMenu.Positioner>
 			</ContextMenu.Portal>


### PR DESCRIPTION
## Summary
- clone chat messages on edit so edits create new cursor-targeted nodes and make unlink jump to the parent
- simplify chat message actions by removing the branch button and moving delete to the end
- strip diagram node controls, leaving only a “Set active cursor here” context option and a read-only layout

## Testing
- bun run build-dist

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912be831b9c8324bbfa4e1d393e9c9f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed per-node "branch" action and related UI; consolidated branch/duplicate flows into a single "Set active node" action and simplified detach/activation behavior.
  * Diagram and context menus updated to surface "Set active node" while keeping duplicate/remove options.

* **New Features**
  * Editing workflow now replaces edited messages with finalized clones and resets composer/editing state for clearer edit/submit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->