### PR TITLE
fix: render DiagramView minimap nodes

### DIFF
--- a/src/components/DiagramView.tsx
+++ b/src/components/DiagramView.tsx
@@ -4,9 +4,11 @@ import {
 	type Edge,
 	MiniMap,
 	type Node,
+	type NodeChange,
 	ReactFlow,
+	applyNodeChanges,
 } from "@xyflow/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import "@xyflow/react/dist/style.css";
 import ELK from "elkjs/lib/elk.bundled.js";
 import { twJoin } from "tailwind-merge";
@@ -184,6 +186,20 @@ const DiagramView = ({
 		null,
 	);
 	const pendingNodeRemovalsRef = useRef<Set<string>>(new Set());
+	const miniMapColors = useMemo(() => {
+		return {
+			nodeColor: (node: Node) =>
+				activePathIds.nodes.has(node.id) ? "#bfdbfe" : "#e2e8f0",
+			nodeStrokeColor: (node: Node) =>
+				activePathIds.nodes.has(node.id) ? "#2563eb" : "#94a3b8",
+		};
+	}, [activePathIds]);
+	const handleNodesChange = useCallback(
+		(changes: NodeChange[]) => {
+			setLayoutNodes((nodes) => applyNodeChanges(changes, nodes));
+		},
+		[setLayoutNodes],
+	);
 
 	useEffect(() => {
 		const children = Object.values(treeNodes).map((node) => ({
@@ -365,6 +381,7 @@ const DiagramView = ({
 								}
 							});
 						}}
+						onNodesChange={handleNodesChange}
 						onNodesDelete={(nodesDeleted) => {
 							nodesDeleted.forEach((node) => {
 								removeNode(node.id);
@@ -379,7 +396,11 @@ const DiagramView = ({
 						}}
 					>
 						<Background />
-						<MiniMap />
+						<MiniMap
+							maskColor="rgba(15, 23, 42, 0.12)"
+							nodeColor={miniMapColors.nodeColor}
+							nodeStrokeColor={miniMapColors.nodeStrokeColor}
+						/>
 					</ReactFlow>
 				</NodeContextMenu>
 			) : (


### PR DESCRIPTION
## Summary
- add an `onNodesChange` handler so React Flow can keep controlled nodes in sync for the minimap
- give the minimap explicit node colors/strokes so it stays legible even when canvas nodes use custom styling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagram now supports interactive node modifications with real-time updates
  * Enhanced minimap with color-coded visualization based on active path state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->