### PR TITLE
feat: integrate built-in AI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A tiny browser‑based chat UI packaged as a single static HTML file. It is inte
 
 1. Click the Settings icon in the header.
 2. Choose a provider:
-	- **OpenAI‑Compatible**: enter a base URL (e.g. `https://api.openai.com/v1`) and API key, then click "Save". Click "Sync from API" to fetch models.
-	- **Built-in AI (Chrome/Edge)**: no API key required. The app will check availability and, if needed, download the built-in model with progress feedback.
+   - **OpenAI‑Compatible**: enter a base URL (e.g. `https://api.openai.com/v1`) and API key, then click "Save". Click "Sync from API" to fetch models.
+   - **Built-in AI (Chrome/Edge)**: no API key required. The app will check availability and, if needed, download the built-in model with progress feedback.
 
 ## Usage Tips
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ A tiny browser‑based chat UI packaged as a single static HTML file. It is inte
 ## Configure API
 
 1. Click the Settings icon in the header.
-2. Enter your OpenAI‑compatible base URL (e.g. `https://api.openai.com/v1`) and API key, then click "Save".
-3. Click "Sync from API" to fetch model list.
+2. Choose a provider:
+	- **OpenAI‑Compatible**: enter a base URL (e.g. `https://api.openai.com/v1`) and API key, then click "Save". Click "Sync from API" to fetch models.
+	- **Built-in AI (Chrome/Edge)**: no API key required. The app will check availability and, if needed, download the built-in model with progress feedback.
 
 ## Usage Tips
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
         "@ai-sdk/openai-compatible": "^1.0.27",
         "@ai-sdk/react": "^2.0.98",
         "@base-ui-components/react": "^1.0.0-beta.4",
+        "@built-in-ai/core": "^2.0.1",
         "@mantine/core": "^7.8.1",
         "@mantine/hooks": "^7.8.1",
         "@xyflow/react": "^12.9.1",
@@ -96,6 +97,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.8.3", "", { "os": "win32", "cpu": "x64" }, "sha512-/PJ59vA1pnQeKahemaQf4Nyj7IKUvGQSc3Ze1uIGi+Wvr1xF7rGobSrAAG01T/gUDG21vkDsZYM03NAmPiVkqg=="],
 
+    "@built-in-ai/core": ["@built-in-ai/core@2.0.1", "https://registry.npmmirror.com/@built-in-ai/core/-/core-2.0.1.tgz", { "dependencies": { "@mediapipe/tasks-text": "^0.10.22-rc.20250304" }, "peerDependencies": { "ai": ">=5.0.0" } }, "sha512-QiW2s3nCLcjCk7Zsm10iIytRLMz1SIrqzoUmEz4Azy5Yu8qtPRqnVTp0ig4qR/0FPuLEPwA4veqR6KNQKgeCtA=="],
+
     "@egoist/tailwindcss-icons": ["@egoist/tailwindcss-icons@1.7.4", "", { "dependencies": { "@iconify/utils": "^2.1.20" }, "peerDependencies": { "tailwindcss": "*" } }, "sha512-883qx0sqeNb8km7os0w8K6UYue88dbgTWwyEUwW74Bgz0H7t+m7PMIIEvSQ4JqHwA823Qd5ciz+NoTBWKaMYfg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.3", "https://registry.npmmirror.com/@floating-ui/core/-/core-1.7.3.tgz", { "dependencies": { "@floating-ui/utils": "^0.2.10" } }, "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w=="],
@@ -129,6 +132,8 @@
     "@mantine/core": ["@mantine/core@7.8.1", "", { "dependencies": { "@floating-ui/react": "^0.26.9", "clsx": "2.1.0", "react-number-format": "^5.3.1", "react-remove-scroll": "^2.5.7", "react-textarea-autosize": "8.5.3", "type-fest": "^4.12.0" }, "peerDependencies": { "@mantine/hooks": "7.8.1", "react": "^18.2.0", "react-dom": "^18.2.0" } }, "sha512-dttbP2BhBzFJYBqgAQedJRca5+MXlJbppRhRsufnFeO7YC/UpZutOoHQ9dxGEQnhAWJ/d+wuRvYWG/gXex+wYQ=="],
 
     "@mantine/hooks": ["@mantine/hooks@7.8.1", "", { "peerDependencies": { "react": "^18.2.0" } }, "sha512-zCLqnxTUR2N6Awbt4rv/26UKTc75dXTVmCPsWUb6wdQExuC28fucG6kMoNYHVmOBDq9f3KP9zWOGDelHM2ogZA=="],
+
+    "@mediapipe/tasks-text": ["@mediapipe/tasks-text@0.10.22-rc.20250304", "https://registry.npmmirror.com/@mediapipe/tasks-text/-/tasks-text-0.10.22-rc.20250304.tgz", {}, "sha512-J2AFxsh+Pra2OZXf+T4iC8p4JeLyLjg7wU7l2mxcNPNY13wmVhYADxkOLSQq7BPRuXj5aBj7A98dBgZh++s6OQ=="],
 
     "@module-federation/runtime": ["@module-federation/runtime@0.0.8", "", { "dependencies": { "@module-federation/sdk": "0.0.8" } }, "sha512-Hi9g10aHxHdQ7CbchSvke07YegYwkf162XPOmixNmJr5Oy4wVa2d9yIVSrsWFhBRbbvM5iJP6GrSuEq6HFO3ug=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
 		"@ai-sdk/openai-compatible": "^1.0.27",
 		"@ai-sdk/react": "^2.0.98",
 		"@base-ui-components/react": "^1.0.0-beta.4",
+		"@built-in-ai/core": "^2.0.1",
 		"@mantine/core": "^7.8.1",
 		"@mantine/hooks": "^7.8.1",
 		"@xyflow/react": "^12.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,34 +82,15 @@ const App = () => {
 		return builtInAI();
 	}, []);
 
-	const normalizeBuiltInAvailability = useCallback(
-		(availability: string | undefined): BuiltInAvailability => {
-			if (availability === "available") {
-				return "available";
-			}
-			if (availability === "downloading") {
-				return "downloading";
-			}
-			if (
-				availability === "downloadable" ||
-				availability === "available-after-download"
-			) {
-				return "downloadable";
-			}
-			return "unavailable";
-		},
-		[],
-	);
-
 	const refreshBuiltInAvailability = useCallback(async () => {
 		try {
 			const availability = await builtInAI().availability();
-			setBuiltInAvailability(normalizeBuiltInAvailability(availability));
+			setBuiltInAvailability(availability as BuiltInAvailability);
 		} catch (error) {
 			console.error(error);
 			setBuiltInAvailability("unavailable");
 		}
-	}, [normalizeBuiltInAvailability]);
+	}, []);
 
 	const syncModels = useCallback(
 		async ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,12 +97,14 @@ const App = () => {
 			baseURLOverride,
 			apiKeyOverride,
 			silent = false,
+			force = false,
 		}: {
 			baseURLOverride?: string;
 			apiKeyOverride?: string;
 			silent?: boolean;
+			force?: boolean;
 		} = {}) => {
-			if (providerKind !== "openai-compatible") {
+			if (!force && providerKind !== "openai-compatible") {
 				return [];
 			}
 			const targetBaseURL = (baseURLOverride ?? baseURL).trim();
@@ -627,6 +629,7 @@ const App = () => {
 				baseURLOverride: nextBaseURL,
 				apiKeyOverride: nextAPIKey,
 				silent: true,
+				force: true,
 			});
 		} else {
 			setActiveModel(null);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,6 +5,9 @@ interface HeaderProps {
 	models: ModelInfo[];
 	activeModel: string | null;
 	onModelChange: (value: string | null) => void;
+	modelSelectorDisabled?: boolean;
+	modelPlaceholder?: string;
+	modelStatus?: string;
 	view: AppView;
 	onViewChange: (value: AppView) => void;
 	onClear: () => void;
@@ -27,6 +30,9 @@ const Header = ({
 	models,
 	activeModel,
 	onModelChange,
+	modelSelectorDisabled = false,
+	modelPlaceholder,
+	modelStatus,
 	view,
 	onViewChange,
 	onClear,
@@ -37,17 +43,24 @@ const Header = ({
 	<div className="flex items-center px-4 py-2">
 		<div className="flex items-center gap-2">
 			<h1 className="text-xl font-bold font-mono">iaslate</h1>
-			<Select
-				className="w-64"
-				data={models.map((model) => ({
-					value: model.id,
-					label: model.name || model.id,
-				}))}
-				value={activeModel}
-				onChange={onModelChange}
-				placeholder="Select a model"
-				aria-label="Select a model"
-			/>
+			{modelSelectorDisabled ? (
+				<div className="flex h-[2.25rem] w-64 items-center rounded-md border border-solid border-slate-300 bg-white px-3 text-sm leading-[1.1] text-slate-900 shadow-xs dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
+					{modelStatus ?? "Model selection disabled"}
+				</div>
+			) : (
+				<Select
+					className="w-64"
+					data={models.map((model) => ({
+						value: model.id,
+						label: model.name || model.id,
+					}))}
+					value={activeModel}
+					onChange={onModelChange}
+					placeholder={modelPlaceholder ?? "Select a model"}
+					disabled={modelSelectorDisabled}
+					aria-label="Select a model"
+				/>
+			)}
 		</div>
 		<div className="ml-4">
 			<SegmentedControl

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -55,25 +55,6 @@ const SettingsModal = ({
 	const [isDownloading, setIsDownloading] = useState(false);
 	const downloadModelRef = useRef<ReturnType<typeof builtInAI> | null>(null);
 
-	const normalizeAvailability = useCallback(
-		(availability: string | undefined): BuiltInAvailability => {
-			if (availability === "available") {
-				return "available";
-			}
-			if (availability === "downloading") {
-				return "downloading";
-			}
-			if (
-				availability === "downloadable" ||
-				availability === "available-after-download"
-			) {
-				return "downloadable";
-			}
-			return "unavailable";
-		},
-		[],
-	);
-
 	const handleCheckBuiltInAvailability = useCallback(async () => {
 		if (isDownloading) {
 			return;
@@ -83,7 +64,7 @@ const SettingsModal = ({
 		try {
 			const model = builtInAI();
 			const availability = await model.availability();
-			onBuiltInAvailabilityChange(normalizeAvailability(availability));
+			onBuiltInAvailabilityChange(availability as BuiltInAvailability);
 		} catch (error) {
 			console.error(error);
 			onBuiltInAvailabilityChange("unavailable");
@@ -93,7 +74,7 @@ const SettingsModal = ({
 					: "Failed to check built-in model status",
 			);
 		}
-	}, [isDownloading, normalizeAvailability, onBuiltInAvailabilityChange]);
+	}, [isDownloading, onBuiltInAvailabilityChange]);
 
 	const handleDownloadModel = useCallback(async () => {
 		if (
@@ -110,7 +91,7 @@ const SettingsModal = ({
 		const model = builtInAI();
 		downloadModelRef.current = model;
 		try {
-			const availability = normalizeAvailability(await model.availability());
+			const availability = (await model.availability()) as BuiltInAvailability;
 			switch (availability) {
 				case "unavailable": {
 					onBuiltInAvailabilityChange("unavailable");
@@ -152,7 +133,6 @@ const SettingsModal = ({
 	}, [
 		builtInAvailability,
 		isDownloading,
-		normalizeAvailability,
 		onBuiltInAvailabilityChange,
 	]);
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -161,16 +161,19 @@ const SettingsModal = ({
 	}, [open]);
 
 	useEffect(() => {
-		if (open && builtInAvailability === "unknown") {
+		if (
+			open &&
+			selectedProvider === "built-in" &&
+			builtInAvailability === "unknown"
+		) {
 			void handleCheckBuiltInAvailability();
 		}
-	}, [builtInAvailability, handleCheckBuiltInAvailability, open]);
-
-	useEffect(() => {
-		if (open && selectedProvider === "built-in") {
-			void handleCheckBuiltInAvailability();
-		}
-	}, [handleCheckBuiltInAvailability, open, selectedProvider]);
+	}, [
+		builtInAvailability,
+		handleCheckBuiltInAvailability,
+		open,
+		selectedProvider,
+	]);
 
 	useEffect(() => {
 		if (open) {

--- a/src/components/TextCompletionView.tsx
+++ b/src/components/TextCompletionView.tsx
@@ -3,6 +3,8 @@ import { Button, Textarea } from "@mantine/core";
 interface TextCompletionViewProps {
 	value: string;
 	isGenerating: boolean;
+	isPredictDisabled?: boolean;
+	disabledReason?: string;
 	onChange: (value: string) => void;
 	onPredict: () => void;
 	onCancel: () => void;
@@ -11,6 +13,8 @@ interface TextCompletionViewProps {
 const TextCompletionView = ({
 	value,
 	isGenerating,
+	isPredictDisabled = false,
+	disabledReason,
 	onChange,
 	onPredict,
 	onCancel,
@@ -38,6 +42,8 @@ const TextCompletionView = ({
 				size="md"
 				variant={isGenerating ? "light" : "filled"}
 				color={isGenerating ? "red" : "blue"}
+				disabled={isPredictDisabled && !isGenerating}
+				title={isPredictDisabled ? disabledReason : undefined}
 				onClick={isGenerating ? onCancel : onPredict}
 				leftSection={
 					<span

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,3 +19,10 @@ export interface ModelInfo {
 }
 
 export type ProviderKind = "openai-compatible" | "built-in";
+
+export type BuiltInAvailability =
+	| "unknown"
+	| "unavailable"
+	| "downloadable"
+	| "downloading"
+	| "available";

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,3 +17,5 @@ export interface ModelInfo {
 	object?: string;
 	owned_by?: string;
 }
+
+export type ProviderKind = "openai-compatible" | "built-in";


### PR DESCRIPTION
- Added support for a new built-in AI provider, allowing users to select between OpenAI-compatible and built-in AI options.
- Updated the App component to manage provider selection and model handling accordingly.
- Enhanced the SettingsModal to include provider selection and adjusted form handling based on the selected provider.
- Updated README with configuration instructions for the new built-in AI provider.
- Refactored components to accommodate the new provider logic and ensure seamless user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dual-provider system: choose OpenAI-Compatible API or Built-in AI (Chrome/Edge).
  * Provider selection persisted and available in Settings with provider-specific UI.
  * Built-in AI auto-checks availability, shows download progress, and can download models.
  * OpenAI inputs (API key, base URL) shown only for OpenAI-Compatible provider.
  * UI adapts: model selector, status text, and predict controls reflect provider and availability.
  * Predict control is disabled with a clear reason when the current provider or model is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->