### PR TITLE
Add image message content support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 - Type-checking: use tsc. Run `bunx tsc --noEmit` to check for type errors.
 - Components: keep UI logic close to the component (e.g., hover/edit toggles in `MessageItem`, menu interactions in `DiagramView`); shared conversation/tree logic belongs in the store.
 - CSS: prefer Tailwind utilities; add global styles in `src/index.css` only when necessary.
+- Tailwind preflight is not enabled; when using `border`, also include `border-solid` (and set a color) to avoid browser defaults.
 
 ## Providers & Capabilities
 

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -229,7 +229,9 @@ const ChatView = ({
 						)}
 						<Textarea
 							className="w-full"
-							classNames={{ input: "px-3 py-2 text-sm leading-5 placeholder:text-slate-400" }}
+							classNames={{
+								input: "px-3 py-2 text-sm leading-5 placeholder:text-slate-400",
+							}}
 							minRows={1}
 							maxRows={5}
 							variant="unstyled"

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,20 +1,23 @@
 import { Textarea, UnstyledButton } from "@mantine/core";
-import { useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { twJoin } from "tailwind-merge";
 import { useImmer } from "use-immer";
-import type { Message } from "../types";
+import type { Message, MessageContent, MessageContentPart } from "../types";
 import MessageItem from "./MessageItem";
 
 interface ChatViewProps {
 	messages: Message[];
 	isGenerating: boolean;
 	editingMessageId?: string;
-	onSend: (prompt: string) => Promise<void> | void;
+	onSend: (prompt: MessageContent) => Promise<void> | void;
 	onStop: () => void;
 	onDeleteMessage: (nodeId: string) => void;
 	onDetachMessage: (nodeId: string) => void;
 	onEditStart: (nodeId: string) => void;
-	onEditSubmit: (nodeId: string, text: string) => Promise<void> | void;
+	onEditSubmit: (
+		nodeId: string,
+		content: MessageContent,
+	) => Promise<void> | void;
 	onEditCancel: () => void;
 	onPromptDirtyChange?: (dirty: boolean) => void;
 	resetSignal?: number;
@@ -35,7 +38,22 @@ const ChatView = ({
 	resetSignal,
 }: ChatViewProps) => {
 	const [prompt, setPrompt] = useImmer("");
+	const [attachments, setAttachments] = useImmer<MessageContentPart[]>([]);
+	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const isComposing = useRef(false);
+
+	const splitContent = useCallback((content: MessageContent) => {
+		if (typeof content === "string") {
+			return { text: content, images: [] as MessageContentPart[] };
+		}
+		return {
+			text: content
+				.filter((part) => part.type === "text")
+				.map((part) => part.text)
+				.join("\n\n"),
+			images: content.filter((part) => part.type === "image"),
+		};
+	}, []);
 
 	const editingMessage = useMemo(
 		() =>
@@ -49,37 +67,97 @@ const ChatView = ({
 
 	useEffect(() => {
 		onPromptDirtyChange?.(
-			prompt.trim().length > 0 || typeof editingMessageId !== "undefined",
+			prompt.trim().length > 0 ||
+				attachments.length > 0 ||
+				typeof editingMessageId !== "undefined",
 		);
 		return () => {
 			onPromptDirtyChange?.(false);
 		};
-	}, [editingMessageId, onPromptDirtyChange, prompt]);
+	}, [attachments.length, editingMessageId, onPromptDirtyChange, prompt]);
 
 	useEffect(() => {
 		if (typeof resetSignal !== "undefined") {
 			setPrompt("");
+			setAttachments([]);
 		}
-	}, [resetSignal, setPrompt]);
+	}, [resetSignal, setAttachments, setPrompt]);
 
 	useEffect(() => {
 		if (editingMessageId && editingMessage) {
-			setPrompt(editingMessage.content);
+			const { text, images } = splitContent(editingMessage.content);
+			setPrompt(text);
+			setAttachments(images);
 		}
-	}, [editingMessage?.content, editingMessageId, setPrompt]);
+	}, [
+		editingMessage?.content,
+		editingMessageId,
+		setAttachments,
+		setPrompt,
+		splitContent,
+	]);
+
+	const buildMessageContent = useCallback((): MessageContent => {
+		const parts: MessageContentPart[] = [];
+		if (prompt.trim().length > 0) {
+			parts.push({ type: "text", text: prompt });
+		}
+		if (attachments.length > 0) {
+			parts.push(...attachments);
+		}
+		if (parts.length === 0) {
+			return "";
+		}
+		const [firstPart] = parts;
+		if (parts.length === 1 && firstPart?.type === "text") {
+			return firstPart.text;
+		}
+		return parts;
+	}, [attachments, prompt]);
+
+	const addImageAttachment = useCallback(
+		(dataUrl: string, mimeType?: string) => {
+			setAttachments((draft) => {
+				draft.push({ type: "image", image: dataUrl, mimeType });
+			});
+		},
+		[setAttachments],
+	);
+
+	const handleFileInput = useCallback(
+		async (file: File) => {
+			if (file.type.startsWith("image/")) {
+				const reader = new FileReader();
+				reader.onload = () => {
+					const result = typeof reader.result === "string" ? reader.result : "";
+					if (result) {
+						addImageAttachment(result, file.type);
+					}
+				};
+				reader.readAsDataURL(file);
+				return;
+			}
+			const content = await file.text();
+			setPrompt((draft) => draft + content);
+		},
+		[addImageAttachment, setPrompt],
+	);
 
 	const handleSubmit = () => {
 		if (isGenerating) {
 			onStop();
 			return;
 		}
+		const nextContent = buildMessageContent();
 		if (editingMessageId) {
-			onEditSubmit(editingMessageId, prompt);
+			onEditSubmit(editingMessageId, nextContent);
 			setPrompt("");
+			setAttachments([]);
 			return;
 		}
-		onSend(prompt);
+		onSend(nextContent);
 		setPrompt("");
+		setAttachments([]);
 	};
 
 	return (
@@ -88,15 +166,10 @@ const ChatView = ({
 				className="flex-1 min-h-0 overflow-y-auto px-4 py-2"
 				onDrop={async (event) => {
 					event.preventDefault();
-					if (event.dataTransfer.items) {
-						for (const item of event.dataTransfer.items) {
-							if (item.kind === "file") {
-								const file = item.getAsFile();
-								if (file) {
-									const content = await file.text();
-									setPrompt((draft) => draft + content);
-								}
-							}
+					const files = event.dataTransfer.files;
+					if (files && files.length > 0) {
+						for (const file of Array.from(files)) {
+							await handleFileInput(file);
 						}
 					}
 				}}
@@ -148,6 +221,15 @@ const ChatView = ({
 					/>
 					<UnstyledButton
 						className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
+						onClick={() => {
+							fileInputRef.current?.click();
+						}}
+						title="Attach image"
+					>
+						<div className="i-lucide-image w-4 h-4" />
+					</UnstyledButton>
+					<UnstyledButton
+						className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
 						onClick={handleSubmit}
 					>
 						<div
@@ -161,17 +243,63 @@ const ChatView = ({
 						/>
 					</UnstyledButton>
 				</div>
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept="image/*"
+					className="hidden"
+					onChange={(event) => {
+						const { files } = event.target;
+						if (files) {
+							for (const file of Array.from(files)) {
+								void handleFileInput(file);
+							}
+							event.target.value = "";
+						}
+					}}
+				/>
+				{attachments.length > 0 && (
+					<div className="mt-2 flex flex-wrap gap-2">
+						{attachments.map((attachment, index) =>
+							attachment.type === "image" ? (
+								<div
+									key={`${attachment.image}-${index}`}
+									className="relative h-16 w-16 overflow-hidden rounded border"
+								>
+									<img
+										src={attachment.image}
+										alt="User attachment"
+										className="h-full w-full object-cover"
+									/>
+									<UnstyledButton
+										className="absolute right-1 top-1 h-5 w-5 rounded-full bg-white/80 text-slate-700 hover:bg-white"
+										onClick={() => {
+											setAttachments((draft) => {
+												draft.splice(index, 1);
+											});
+										}}
+										title="Remove attachment"
+									>
+										<div className="i-lucide-x w-4 h-4" />
+									</UnstyledButton>
+								</div>
+							) : null,
+						)}
+					</div>
+				)}
 				{editingMessage && (
 					<div className="absolute left-4 -top-8 h-8 w-[calc(100%-2rem)] rounded bg-orange-300 p-2 flex items-center text-slate-700 text-sm">
 						<div className="i-lucide-edit flex-none" />
 						<p className="ml-1 line-clamp-1">
-							Editing: {editingMessage.content}
+							Editing:{" "}
+							{splitContent(editingMessage.content).text || "(image content)"}
 						</p>
 						<UnstyledButton
 							className="i-lucide-x ml-auto flex-none"
 							onClick={() => {
 								onEditCancel();
 								setPrompt("");
+								setAttachments([]);
 							}}
 						/>
 					</div>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -192,35 +192,73 @@ const ChatView = ({
 			</div>
 			<div className="relative px-4 py-2">
 				<div className="flex items-center">
-					<Textarea
-						className="w-full"
-						minRows={1}
-						maxRows={5}
-						placeholder="Type your message..."
-						value={prompt}
-						onChange={(event) => {
-							setPrompt(event.target.value);
-						}}
-						onCompositionStart={() => {
-							isComposing.current = true;
-						}}
-						onCompositionEnd={() => {
-							isComposing.current = false;
-						}}
-						onKeyDown={(event) => {
-							if (
-								event.key === "Enter" &&
-								!event.shiftKey &&
-								!event.nativeEvent.isComposing &&
-								!isComposing.current
-							) {
-								event.preventDefault();
-								handleSubmit();
-							}
-						}}
-					/>
+					<div className="flex-1 overflow-hidden rounded-lg border border-solid border-slate-200 bg-white shadow-sm">
+						{attachments.length > 0 && (
+							<div className="flex flex-wrap items-center gap-2 px-3 py-2">
+								{attachments.map((attachment, index) =>
+									attachment.type === "image" ? (
+										<div
+											key={`${attachment.image}-${index}`}
+											className="flex items-center gap-2 rounded-full bg-white px-2 py-1 text-slate-700 shadow-sm ring-1 ring-slate-200"
+										>
+											<div className="h-7 w-7 overflow-hidden rounded-full bg-slate-100 ring-1 ring-slate-200">
+												<img
+													src={attachment.image}
+													alt="User attachment"
+													className="h-full w-full object-cover"
+												/>
+											</div>
+											<span className="text-xs font-medium leading-none">
+												Image {index + 1}
+											</span>
+											<UnstyledButton
+												className="ml-1 flex h-5 w-5 items-center justify-center rounded-full text-slate-600 hover:bg-slate-200"
+												onClick={() => {
+													setAttachments((draft) => {
+														draft.splice(index, 1);
+													});
+												}}
+												title="Remove attachment"
+											>
+												<div className="i-lucide-x w-4 h-4" />
+											</UnstyledButton>
+										</div>
+									) : null,
+								)}
+							</div>
+						)}
+						<Textarea
+							className="w-full"
+							classNames={{ input: "px-3 py-2 text-sm leading-5 placeholder:text-slate-400" }}
+							minRows={1}
+							maxRows={5}
+							variant="unstyled"
+							placeholder="Type your message..."
+							value={prompt}
+							onChange={(event) => {
+								setPrompt(event.target.value);
+							}}
+							onCompositionStart={() => {
+								isComposing.current = true;
+							}}
+							onCompositionEnd={() => {
+								isComposing.current = false;
+							}}
+							onKeyDown={(event) => {
+								if (
+									event.key === "Enter" &&
+									!event.shiftKey &&
+									!event.nativeEvent.isComposing &&
+									!isComposing.current
+								) {
+									event.preventDefault();
+									handleSubmit();
+								}
+							}}
+						/>
+					</div>
 					<UnstyledButton
-						className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
+						className="ml-3 border border-solid border-slate-300 rounded-full w-8 h-8 flex items-center justify-center"
 						onClick={() => {
 							fileInputRef.current?.click();
 						}}
@@ -229,7 +267,7 @@ const ChatView = ({
 						<div className="i-lucide-image w-4 h-4" />
 					</UnstyledButton>
 					<UnstyledButton
-						className="ml-2 border rounded-full w-8 h-8 flex items-center justify-center"
+						className="ml-2 border border-solid border-slate-300 rounded-full w-8 h-8 flex items-center justify-center"
 						onClick={handleSubmit}
 					>
 						<div
@@ -258,35 +296,6 @@ const ChatView = ({
 						}
 					}}
 				/>
-				{attachments.length > 0 && (
-					<div className="mt-2 flex flex-wrap gap-2">
-						{attachments.map((attachment, index) =>
-							attachment.type === "image" ? (
-								<div
-									key={`${attachment.image}-${index}`}
-									className="relative h-16 w-16 overflow-hidden rounded border"
-								>
-									<img
-										src={attachment.image}
-										alt="User attachment"
-										className="h-full w-full object-cover"
-									/>
-									<UnstyledButton
-										className="absolute right-1 top-1 h-5 w-5 rounded-full bg-white/80 text-slate-700 hover:bg-white"
-										onClick={() => {
-											setAttachments((draft) => {
-												draft.splice(index, 1);
-											});
-										}}
-										title="Remove attachment"
-									>
-										<div className="i-lucide-x w-4 h-4" />
-									</UnstyledButton>
-								</div>
-							) : null,
-						)}
-					</div>
-				)}
 				{editingMessage && (
 					<div className="absolute left-4 -top-8 h-8 w-[calc(100%-2rem)] rounded bg-orange-300 p-2 flex items-center text-slate-700 text-sm">
 						<div className="i-lucide-edit flex-none" />

--- a/src/components/DiagramView.tsx
+++ b/src/components/DiagramView.tsx
@@ -257,6 +257,13 @@ const DiagramView = ({
 		});
 
 		const nodes: Node[] = sortedNodes.map((dataNode) => {
+			const contentText =
+				typeof dataNode.content === "string"
+					? dataNode.content
+					: dataNode.content
+							.filter((part) => part.type === "text")
+							.map((part) => part.text)
+							.join("\n\n");
 			const label = (
 				<div className="flex items-start gap-2">
 					<div className="min-w-0">
@@ -264,7 +271,7 @@ const DiagramView = ({
 							{dataNode.role}
 						</p>
 						<p className="mt-1 text-sm font-medium leading-snug text-slate-800 line-clamp-3">
-							{dataNode.text}
+							{contentText}
 						</p>
 					</div>
 				</div>

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -145,9 +145,7 @@ const MessageItem = ({
 								}`}
 							</Markdown>
 						) : (
-							<div
-								key={`${message._metadata.uuid}-image-${index}`}
-							>
+							<div key={`${message._metadata.uuid}-image-${index}`}>
 								<img
 									src={part.image}
 									alt="User provided"

--- a/src/components/MessageItem.tsx
+++ b/src/components/MessageItem.tsx
@@ -147,7 +147,6 @@ const MessageItem = ({
 						) : (
 							<div
 								key={`${message._metadata.uuid}-image-${index}`}
-								className="mt-2"
 							>
 								<img
 									src={part.image}

--- a/src/hooks/useConversationController.ts
+++ b/src/hooks/useConversationController.ts
@@ -93,6 +93,7 @@ export const useConversationController = ({
 					) {
 						return false;
 					}
+					continue;
 				}
 			}
 			return true;

--- a/src/hooks/useConversationController.ts
+++ b/src/hooks/useConversationController.ts
@@ -3,7 +3,7 @@ import { toast } from "sonner";
 import { useShallow } from "zustand/react/shallow";
 import { sendMessage } from "../ai/sendMessage";
 import { useConversationTree } from "../tree/useConversationTree";
-import type { ChatProviderReady, Message } from "../types";
+import type { ChatProviderReady, Message, MessageContent } from "../types";
 import { deleteMessage } from "../utils/chatActions";
 import { useStreamManager } from "./useStreamManager";
 
@@ -63,27 +63,67 @@ export const useConversationController = ({
 		})),
 	);
 
-	const areMessagesEqual = useCallback((next: Message[], prev: Message[]) => {
-		if (next === prev) {
-			return true;
-		}
-		if (next.length !== prev.length) {
-			return false;
-		}
-		for (let index = 0; index < next.length; index++) {
-			const a = next[index];
-			const b = prev[index];
-			if (
-				a._metadata.uuid !== b._metadata.uuid ||
-				a.role !== b.role ||
-				a.content !== b.content ||
-				a.reasoning_content !== b.reasoning_content
-			) {
+	const areContentsEqual = useCallback(
+		(aContent: MessageContent, bContent: MessageContent) => {
+			if (aContent === bContent) {
+				return true;
+			}
+			if (typeof aContent === "string" || typeof bContent === "string") {
+				return aContent === bContent;
+			}
+			if (aContent.length !== bContent.length) {
 				return false;
 			}
-		}
-		return true;
-	}, []);
+			for (let index = 0; index < aContent.length; index++) {
+				const partA = aContent[index]!;
+				const partB = bContent[index]!;
+				if (partA.type !== partB.type) {
+					return false;
+				}
+				if (partA.type === "text" && partB.type === "text") {
+					if (partA.text !== partB.text) {
+						return false;
+					}
+					continue;
+				}
+				if (partA.type === "image" && partB.type === "image") {
+					if (
+						partA.image !== partB.image ||
+						partA.mimeType !== partB.mimeType
+					) {
+						return false;
+					}
+				}
+			}
+			return true;
+		},
+		[],
+	);
+
+	const areMessagesEqual = useCallback(
+		(next: Message[], prev: Message[]) => {
+			if (next === prev) {
+				return true;
+			}
+			if (next.length !== prev.length) {
+				return false;
+			}
+			for (let index = 0; index < next.length; index++) {
+				const a = next[index]!;
+				const b = prev[index]!;
+				if (
+					a._metadata.uuid !== b._metadata.uuid ||
+					a.role !== b.role ||
+					!areContentsEqual(a.content, b.content) ||
+					a.reasoning_content !== b.reasoning_content
+				) {
+					return false;
+				}
+			}
+			return true;
+		},
+		[areContentsEqual],
+	);
 
 	const chatMessages = useConversationTree(
 		useCallback((state) => state.compileActive(), []),
@@ -120,13 +160,13 @@ export const useConversationController = ({
 	]);
 
 	const handleSend = useCallback(
-		async (promptText: string) => {
+		async (promptContent: MessageContent) => {
 			const chatProvider = ensureChatReady();
 			if (!chatProvider) {
 				return;
 			}
 			try {
-				await sendMessage(promptText, {
+				await sendMessage(promptContent, {
 					provider: chatProvider,
 					activeTargetId,
 					activeTail,
@@ -223,9 +263,9 @@ export const useConversationController = ({
 	);
 
 	const handleFinishEdit = useCallback(
-		(nodeId: string, text: string) => {
+		(nodeId: string, content: MessageContent) => {
 			const replacementId = replaceNodeWithEditedClone(nodeId, {
-				text,
+				content,
 			});
 			if (!replacementId) {
 				return;

--- a/src/tree/types.ts
+++ b/src/tree/types.ts
@@ -1,3 +1,5 @@
+import type { MessageContent } from "../types";
+
 export type NodeID = string;
 export type EdgeID = string;
 export type EdgeKind = "sequence";
@@ -5,7 +7,7 @@ export type EdgeKind = "sequence";
 export interface TreeNode {
 	id: NodeID;
 	role: "system" | "user" | "assistant" | "tool";
-	content: import("../types").MessageContent;
+	content: MessageContent;
 	reasoningContent?: string;
 	createdAt: number;
 	status?: "draft" | "streaming" | "final" | "error";

--- a/src/tree/types.ts
+++ b/src/tree/types.ts
@@ -5,7 +5,7 @@ export type EdgeKind = "sequence";
 export interface TreeNode {
 	id: NodeID;
 	role: "system" | "user" | "assistant" | "tool";
-	text: string;
+	content: import("../types").MessageContent;
 	reasoningContent?: string;
 	createdAt: number;
 	status?: "draft" | "streaming" | "final" | "error";

--- a/src/tree/types.ts
+++ b/src/tree/types.ts
@@ -25,8 +25,8 @@ export interface ConversationTree {
 	roots: NodeID[];
 }
 
-export interface ConversationSnapshotV1 {
-	version: 1;
+export interface ConversationSnapshotV2 {
+	version: 2;
 	exportedAt: string;
 	tree: {
 		nodes: Record<NodeID, TreeNode>;
@@ -34,4 +34,4 @@ export interface ConversationSnapshotV1 {
 	activeTargetId?: NodeID;
 }
 
-export type ConversationSnapshot = ConversationSnapshotV1;
+export type ConversationSnapshot = ConversationSnapshotV2;

--- a/src/tree/useConversationTree.ts
+++ b/src/tree/useConversationTree.ts
@@ -515,7 +515,7 @@ export const useConversationTree = createWithEqualityFn<TreeState>(
 				]),
 			);
 			return {
-				version: 1,
+				version: 2,
 				exportedAt: new Date().toISOString(),
 				tree: {
 					nodes,
@@ -524,7 +524,7 @@ export const useConversationTree = createWithEqualityFn<TreeState>(
 			} satisfies ConversationSnapshot;
 		},
 		importSnapshot: (snapshot) => {
-			if (snapshot.version !== 1) {
+			if (snapshot.version !== 2) {
 				throw new Error(`Unsupported snapshot version: ${snapshot.version}`);
 			}
 			const nodesRaw = snapshot.tree?.nodes ?? {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,15 @@ export interface MessageMetadata {
 	uuid: string;
 }
 
+export type MessageContentPart =
+	| { type: "text"; text: string }
+	| { type: "image"; image: string; mimeType?: string };
+
+export type MessageContent = string | MessageContentPart[];
+
 export interface Message {
 	role: "system" | "user" | "assistant" | "tool";
-	content: string;
+	content: MessageContent;
 	reasoning_content?: string;
 	_metadata: MessageMetadata;
 }


### PR DESCRIPTION
## Summary
- allow chat messages to include image parts and propagate through tree storage
- render image attachments in chat, clipboard handling, and diagram view labels
- update message sending to accept mixed content for AI SDK compatibility

## Testing
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692473ffa65483249ca46028e0f70b01)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image attachments in chat (drag-and-drop and file picker), preview bar, thumbnails, and 10MB limit; text files can be appended.
  * Rich message composition & editing: messages can mix text and images and edits preserve mixed content.
  * Improved copy behavior: non-text parts clearly noted when copying.

* **Documentation**
  * Clarified CSS/Tailwind guidance: when preflight is disabled, include explicit border style and color.

* **Chores**
  * Conversation snapshot/storage upgraded to support richer content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->